### PR TITLE
Move `group` to `apiVersion` for triggers and context

### DIFF
--- a/config/crd/bases/espejote.io_managedresources.yaml
+++ b/config/crd/bases/espejote.io_managedresources.yaml
@@ -244,10 +244,9 @@ spec:
                         `local esp = import "espejote.libsonnet"; esp.triggerType() == esp.TriggerTypeWatchResource` will be true if the render was triggered by a definition in this block.
                       properties:
                         apiVersion:
-                          description: APIVersion of the resource that should be watched.
-                          type: string
-                        group:
-                          description: Group of the resource that should be watched.
+                          description: |-
+                            APIVersion of the resource that should be watched.
+                            The APIVersion can be in the form "group/version" or "version".
                           type: string
                         ignoreNames:
                           description: |-

--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -695,7 +695,7 @@ func (r *ManagedResourceReconciler) newCacheForResourceAndRESTClient(ctx context
 	watchTarget := &unstructured.Unstructured{}
 	watchTarget.SetGroupVersionKind(schema.GroupVersionKind{
 		Group:   cr.GetGroup(),
-		Version: cr.GetAPIVersion(),
+		Version: cr.GetVersion(),
 		Kind:    cr.GetKind(),
 	})
 

--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -294,8 +294,8 @@ Resource information is injected when rendering the template and can be retrieve
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`apiVersion`* __string__ | APIVersion of the resource that should be watched. + |  | 
-| *`group`* __string__ | Group of the resource that should be watched. + |  | 
+| *`apiVersion`* __string__ | APIVersion of the resource that should be watched. +
+The APIVersion can be in the form "group/version" or "version". + |  | 
 | *`kind`* __string__ | Kind of the resource that should be watched. + |  | 
 | *`name`* __string__ | Name of the resource that should be watched. +
 If not set, all resources of the specified Kind are watched. + |  | 


### PR DESCRIPTION
Makes triggers and contexts more intuitive to configure by using the same field combination (apiVersion+kind) as all kubernetes manifests.

```
context:
- name: netpols
  resources:
    apiVersion: v1
    group: networking.k8s.io
    kind: NetworkPolicy
```

becomes:

```
context:
- name: netpols
  resources:
    apiVersion: networking.k8s.io/v1
    kind: NetworkPolicy
```

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
