### PR TITLE
Fix incomplete removal of `context.group` field

### DIFF
--- a/api/v1alpha1/managed_resource_types.go
+++ b/api/v1alpha1/managed_resource_types.go
@@ -138,6 +138,10 @@ type TriggerWatchResource struct {
 	IgnoreNames []string `json:"ignoreNames,omitempty"`
 }
 
+// Resource definitions should be kept in sync.
+// Only difference is the doc strings.
+var _ = ContextResource(TriggerWatchResource{})
+
 func (t TriggerWatchResource) GetVersion() string {
 	if p := strings.SplitN(t.APIVersion, "/", 2); len(p) == 2 {
 		return p[1]
@@ -180,7 +184,7 @@ func (t TriggerWatchResource) String() string {
 	gvk := metav1.GroupVersionKind{
 		Group:   t.GetGroup(),
 		Version: t.GetVersion(),
-		Kind:    t.Kind,
+		Kind:    t.GetKind(),
 	}
 	ns := "empty"
 	if t.Namespace != nil {
@@ -203,9 +207,8 @@ var _ ClusterResource = ContextResource{}
 
 type ContextResource struct {
 	// APIVersion of the resource that should be added to the context.
+	// The APIVersion can be in the form "group/version" or "version".
 	APIVersion string `json:"apiVersion,omitempty"`
-	// Group of the resource that should be added to the context.
-	Group string `json:"group,omitempty"`
 	// Kind of the resource that should be added to the context.
 	Kind string `json:"kind,omitempty"`
 
@@ -234,11 +237,17 @@ type ContextResource struct {
 }
 
 func (t ContextResource) GetVersion() string {
+	if p := strings.SplitN(t.APIVersion, "/", 2); len(p) == 2 {
+		return p[1]
+	}
 	return t.APIVersion
 }
 
 func (t ContextResource) GetGroup() string {
-	return t.Group
+	if p := strings.SplitN(t.APIVersion, "/", 2); len(p) == 2 {
+		return p[0]
+	}
+	return ""
 }
 
 func (t ContextResource) GetKind() string {
@@ -267,9 +276,9 @@ func (t ContextResource) GetIgnoreNames() []string {
 
 func (t ContextResource) String() string {
 	gvk := metav1.GroupVersionKind{
-		Group:   t.Group,
-		Version: t.APIVersion,
-		Kind:    t.Kind,
+		Group:   t.GetGroup(),
+		Version: t.GetVersion(),
+		Kind:    t.GetKind(),
 	}
 	ns := "empty"
 	if t.Namespace != nil {

--- a/config/crd/bases/espejote.io_managedresources.yaml
+++ b/config/crd/bases/espejote.io_managedresources.yaml
@@ -93,12 +93,9 @@ spec:
                         Adds a list of zero or more resources to the context.
                       properties:
                         apiVersion:
-                          description: APIVersion of the resource that should be added
-                            to the context.
-                          type: string
-                        group:
-                          description: Group of the resource that should be added
-                            to the context.
+                          description: |-
+                            APIVersion of the resource that should be added to the context.
+                            The APIVersion can be in the form "group/version" or "version".
                           type: string
                         ignoreNames:
                           description: |-

--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -594,9 +594,9 @@ func (r *Renderer) renderContexts(ctx context.Context, getReader func(string) (c
 		}
 		var contextObj unstructured.Unstructured
 		contextObj.SetGroupVersionKind(schema.GroupVersionKind{
-			Group:   con.Resource.Group,
-			Version: con.Resource.APIVersion,
-			Kind:    con.Resource.Kind,
+			Group:   con.Resource.GetGroup(),
+			Version: con.Resource.GetVersion(),
+			Kind:    con.Resource.GetKind(),
 		})
 		contextObjs, err := contextObj.ToList()
 		if err != nil {

--- a/docs/api.adoc
+++ b/docs/api.adoc
@@ -76,8 +76,8 @@ Defaults to "Strict". + | Strict | Enum: [Ignore Strict] +
 [cols="20a,50a,15a,15a", options="header"]
 |===
 | Field | Description | Default | Validation
-| *`apiVersion`* __string__ | APIVersion of the resource that should be added to the context. + |  | 
-| *`group`* __string__ | Group of the resource that should be added to the context. + |  | 
+| *`apiVersion`* __string__ | APIVersion of the resource that should be added to the context. +
+The APIVersion can be in the form "group/version" or "version". + |  | 
 | *`kind`* __string__ | Kind of the resource that should be added to the context. + |  | 
 | *`name`* __string__ | Name of the resource that should be added to the context. +
 If not set, all resources of the specified Kind are added to the context. + |  | 


### PR DESCRIPTION
Follow up of #22.

A `var` directive now ensures the structs stay in sync.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
