### PR TITLE
Fix possible race during test initialization

### DIFF
--- a/cmd/collect_input.go
+++ b/cmd/collect_input.go
@@ -49,8 +49,9 @@ type collectInputCommandConfig struct {
 }
 
 func (rcc *collectInputCommandConfig) runCollectInput(cmd *cobra.Command, args []string) error {
-	renderNamespace, err := cmd.Flags().GetString("namespace")
-	if err != nil {
+	renderNamespace, nserr := cmd.Flags().GetString("namespace")
+	jsonnetLibraryNamespace, jnserr := cmd.Flags().GetString("jsonnet-library-namespace")
+	if err := multierr.Combine(nserr, jnserr); err != nil {
 		return fmt.Errorf("failed to get flags: %w", err)
 	}
 

--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -62,6 +62,11 @@ func newScheme() *runtime.Scheme {
 }
 
 func runController(cmd *cobra.Command, _ []string) error {
+	jsonnetLibraryNamespace, err := cmd.Flags().GetString("jsonnet-library-namespace")
+	if err != nil {
+		return fmt.Errorf("failed to get flags: %w", err)
+	}
+
 	scheme := newScheme()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))

--- a/cmd/render.go
+++ b/cmd/render.go
@@ -94,7 +94,8 @@ type RenderInputContext struct {
 func (rcc *renderCommandConfig) runRender(cmd *cobra.Command, args []string) error {
 	renderNamespace, rnerr := cmd.Flags().GetString("namespace")
 	renderInputs, rierr := cmd.Flags().GetStringArray("input")
-	if err := multierr.Combine(rnerr, rierr); err != nil {
+	jsonnetLibraryNamespace, jlnerr := cmd.Flags().GetString("jsonnet-library-namespace")
+	if err := multierr.Combine(rnerr, rierr, jlnerr); err != nil {
 		return fmt.Errorf("failed to get flags: %w", err)
 	}
 
@@ -113,7 +114,7 @@ func (rcc *renderCommandConfig) runRender(cmd *cobra.Command, args []string) err
 	if len(renderInputs) > 0 {
 		return rcc.renderFromInputFiles(ctx, cmd.OutOrStdout(), mr, renderInputs)
 	}
-	return rcc.renderFromCluster(ctx, cmd.OutOrStdout(), mr, renderNamespace)
+	return rcc.renderFromCluster(ctx, cmd.OutOrStdout(), mr, renderNamespace, jsonnetLibraryNamespace)
 }
 
 func (rcc *renderCommandConfig) renderFromInputFiles(ctx context.Context, out io.Writer, mr espejotev1alpha1.ManagedResource, renderInputs []string) error {
@@ -236,7 +237,7 @@ func (r *staticUnstructuredReader) List(ctx context.Context, list client.ObjectL
 	return nil
 }
 
-func (rcc *renderCommandConfig) renderFromCluster(ctx context.Context, out io.Writer, mr espejotev1alpha1.ManagedResource, renderNamespace string) error {
+func (rcc *renderCommandConfig) renderFromCluster(ctx context.Context, out io.Writer, mr espejotev1alpha1.ManagedResource, renderNamespace, jsonnetLibraryNamespace string) error {
 	scheme := newScheme()
 
 	if renderNamespace != "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,15 +7,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-var jsonnetLibraryNamespace string
-
 func registerJsonnetLibraryNamespaceFlag(cmd *cobra.Command) {
 	defaultNamespace := "default"
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
 		defaultNamespace = ns
 	}
 
-	cmd.Flags().StringVar(&jsonnetLibraryNamespace, "jsonnet-library-namespace", defaultNamespace, "The namespace to look for shared (`lib/`) Jsonnet libraries in.")
+	cmd.Flags().String("jsonnet-library-namespace", defaultNamespace, "The namespace to look for shared (`lib/`) Jsonnet libraries in.")
 }
 
 var rootCmd = &cobra.Command{


### PR DESCRIPTION
Defines the shared flag `jsonnet-library-namespace` on commands instead of a package scoped variable.

Does not affect us with the current tests but the go race detector sometimes shows it as a problem.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
