### PR TITLE
`espejote.libsonnet`: add `assertPatch()` function to test admission patches

### DIFF
--- a/admission/handler_test.go
+++ b/admission/handler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -141,9 +142,9 @@ func Test_Handler_Patched(t *testing.T) {
 
   local user = admission.admissionRequest().userInfo.username;
 
-  admission.patched("get patched",[
+  admission.patched("get patched", admission.assertPatch([
     admission.jsonPatchOp("add", "/metadata/annotations/request-user", user),
-  ])
+  ]))
 `,
 		},
 	})
@@ -157,6 +158,18 @@ func Test_Handler_Patched(t *testing.T) {
 		UserInfo: authenticationv1.UserInfo{
 			Username: "testuser",
 		},
+		Object: objectToRaw(t, &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+				Annotations: map[string]string{
+					"blub": "blab",
+				},
+			},
+		}),
 	})
 	subject.ServeHTTP(w, req)
 	res := w.Result()
@@ -171,6 +184,63 @@ func Test_Handler_Patched(t *testing.T) {
 	assert.Equal(t, http.StatusOK, int(admres.Response.Result.Code))
 	assert.Equal(t, "get patched", admres.Response.Result.Message)
 	assert.JSONEq(t, `[{"op":"add","path":"/metadata/annotations/request-user","value":"testuser"}]`, string(admres.Response.Patch))
+}
+
+func Test_Handler_Patched_InvalidPatch(t *testing.T) {
+	t.Parallel()
+
+	c := buildFakeClient(t, &espejotev1alpha1.Admission{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+		},
+		Spec: espejotev1alpha1.AdmissionSpec{
+			Template: `
+  local esp = import 'espejote.libsonnet';
+  local admission = esp.ALPHA.admission;
+
+  local user = admission.admissionRequest().userInfo.username;
+
+  admission.patched("get patched", admission.assertPatch([
+    admission.jsonPatchOp("add", "/metadata/annotations/request-user", user),
+  ]))
+`,
+		},
+	})
+
+	subject := espadmission.NewHandler(c, "default")
+	require.NotNil(t, subject)
+
+	w := httptest.NewRecorder()
+	req := newAdmissionRequest(t, "test", "default", admissionv1.AdmissionRequest{
+		UID: "test",
+		UserInfo: authenticationv1.UserInfo{
+			Username: "testuser",
+		},
+		Object: objectToRaw(t, &corev1.Namespace{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "Namespace",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+		}),
+	})
+	subject.ServeHTTP(w, req)
+	res := w.Result()
+	require.Equal(t, http.StatusOK, res.StatusCode)
+
+	require.NotNil(t, res.Body)
+	defer res.Body.Close()
+	var admres admissionv1.AdmissionReview
+	require.NoError(t, json.NewDecoder(res.Body).Decode(&admres))
+	require.NotNil(t, admres.Response)
+	require.NotNil(t, admres.Response.Result)
+	assert.Equal(t, http.StatusInternalServerError, int(admres.Response.Result.Code))
+	assert.Contains(t, admres.Response.Result.Message, "add operation does not apply")
+	assert.Contains(t, admres.Response.Result.Message, "doc is missing path")
+	assert.Contains(t, admres.Response.Result.Message, "/metadata/annotations/request-user")
 }
 
 func newAdmissionRequest(t *testing.T, name, namespace string, admreq admissionv1.AdmissionRequest) *http.Request {
@@ -189,6 +259,14 @@ func newAdmissionRequest(t *testing.T, name, namespace string, admreq admissionv
 	req.SetPathValue("name", name)
 	req.SetPathValue("namespace", namespace)
 	return req
+}
+
+func objectToRaw(t *testing.T, obj client.Object) runtime.RawExtension {
+	t.Helper()
+
+	raw, err := json.Marshal(obj)
+	require.NoError(t, err)
+	return runtime.RawExtension{Raw: raw}
 }
 
 func buildFakeClient(t *testing.T, objs ...client.Object) client.WithWatch {

--- a/controllers/lib/espejote.libsonnet
+++ b/controllers/lib/espejote.libsonnet
@@ -29,10 +29,20 @@ local admission = {
     value: value,
   },
 
+  // assertPatch applies a JSON patch to an object and asserts that the patch was successful.
+  // It expects an array of JSONPatch operations.
+  // Returns the patch.
+  assertPatch: function(patches, obj=self.admissionRequest().object)
+    assert std.isArray(patches) : 'patches must be an array, is: %s' % std.manifestJsonMinified(patches);
+    local applied = std.native('__internal_use_espejote_lib_function_apply_json_patch')(obj, patches);
+    assert applied[1] == null : 'JSON patch failed: %s' % applied[1];
+    patches,
+
   // patched returns an admission response that allows the operation and includes a list of JSON patches.
   // The patches should be a list of JSONPatch operations.
   // JSONPatch operations can be created using the jsonPatchOp() function.
   // The patches are applied in order.
+  // It is highly recommended to use assertPatch() to test the patches before returning them.
   patched: function(msg, patches) {
     assert std.isString(msg) : 'msg must be a string, is: %s' % std.manifestJsonMinified(msg),
     assert std.isArray(patches) : 'patches must be an array, is: %s' % std.manifestJsonMinified(patches),


### PR DESCRIPTION
## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
