### PR TITLE
Fix crash when using `admission.assertPatch` with integers

### DIFF
--- a/admission/handler.go
+++ b/admission/handler.go
@@ -2,6 +2,7 @@ package admission
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -13,7 +14,6 @@ import (
 	"gomodules.xyz/jsonpatch/v2"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"

--- a/admission/handler_test.go
+++ b/admission/handler_test.go
@@ -12,11 +12,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -158,16 +160,19 @@ func Test_Handler_Patched(t *testing.T) {
 		UserInfo: authenticationv1.UserInfo{
 			Username: "testuser",
 		},
-		Object: objectToRaw(t, &corev1.Namespace{
+		Object: objectToRaw(t, &appsv1.Deployment{
 			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Namespace",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test",
 				Annotations: map[string]string{
-					"blub": "blab",
+					"test": "test",
 				},
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To(int32(3)),
 			},
 		}),
 	})


### PR DESCRIPTION
Current go-jsonnet only supports `float64` as NativeFunction return values. See <https://github.com/google/go-jsonnet/issues/761> and <https://github.com/google/go-jsonnet/pull/753>.

This PR ensures the `__internal_use_espejote_lib_function_apply_json_patch` function only returns `float64` by switching the kubernetes json unmarshaler to the `encoding/json` unmarshaler.

As we unmarshal into `any` we don't need any special handling from the kubernetes unmarshaller.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
