### PR TITLE
Add status and readiness metrics

### DIFF
--- a/cmd/controller.go
+++ b/cmd/controller.go
@@ -174,6 +174,7 @@ func runController(cmd *cobra.Command, _ []string) error {
 		return fmt.Errorf("unable to create ManagedResource controller: %w", err)
 	}
 	metrics.Registry.MustRegister(&controllers.CacheSizeCollector{ManagedResourceReconciler: mrr})
+	metrics.Registry.MustRegister(&controllers.ManagedResourceStatusCollector{Reader: mgr.GetClient()})
 
 	if enableDynamicAdmissionWebhook {
 		if err := (&controllers.AdmissionReconciler{

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -54,10 +54,15 @@ func Test_ManagedResourceStatusCollector(t *testing.T) {
 		espejote_managedresource_status{managedresource="empty",namespace="default",status=""} 1
 		espejote_managedresource_status{managedresource="error",namespace="default",status="DependencyConfigurationError"} 1
 		espejote_managedresource_status{managedresource="ready",namespace="default",status="Ready"} 1
-	`
+		# HELP espejote_managedresource_status_ready Ready status of the managed resource. 1 if ready, 0 if any other status. Read from the resources .status.status field.
+		# TYPE espejote_managedresource_status_ready gauge
+		espejote_managedresource_status_ready{managedresource="empty",namespace="default"} 0
+		espejote_managedresource_status_ready{managedresource="error",namespace="default"} 0
+		espejote_managedresource_status_ready{managedresource="ready",namespace="default"} 1
+		`
 
 	require.NoError(t,
-		testutil.CollectAndCompare(subject, strings.NewReader(metrics), "espejote_managedresource_status"),
+		testutil.CollectAndCompare(subject, strings.NewReader(metrics), "espejote_managedresource_status", "espejote_managedresource_status_ready"),
 	)
 }
 

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -1,0 +1,75 @@
+package controllers_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	espejotev1alpha1 "github.com/vshn/espejote/api/v1alpha1"
+	"github.com/vshn/espejote/controllers"
+)
+
+func Test_ManagedResourceStatusCollector(t *testing.T) {
+	c := buildFakeClient(t,
+		&espejotev1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "empty",
+				Namespace: "default",
+			},
+		},
+		&espejotev1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "ready",
+				Namespace: "default",
+			},
+			Status: espejotev1alpha1.ManagedResourceStatus{
+				Status: "Ready",
+			},
+		},
+		&espejotev1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "error",
+				Namespace: "default",
+			},
+			Status: espejotev1alpha1.ManagedResourceStatus{
+				Status: "DependencyConfigurationError",
+			},
+		},
+	)
+
+	subject := &controllers.ManagedResourceStatusCollector{
+		Reader: c,
+	}
+
+	metrics := `
+		# HELP espejote_managedresource_status Status of the managed resource. Read from the resources .status.status field.
+		# TYPE espejote_managedresource_status gauge
+		espejote_managedresource_status{managedresource="empty",namespace="default",status=""} 1
+		espejote_managedresource_status{managedresource="error",namespace="default",status="DependencyConfigurationError"} 1
+		espejote_managedresource_status{managedresource="ready",namespace="default",status="Ready"} 1
+	`
+
+	require.NoError(t,
+		testutil.CollectAndCompare(subject, strings.NewReader(metrics), "espejote_managedresource_status"),
+	)
+}
+
+func buildFakeClient(t *testing.T, objs ...client.Object) client.WithWatch {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, clientgoscheme.AddToScheme(scheme))
+	require.NoError(t, espejotev1alpha1.AddToScheme(scheme))
+
+	return fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(objs...).
+		Build()
+}


### PR DESCRIPTION
The collector reads the `.status.status` field of the managed resources.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.

<!--
Remove items that do not apply. For completed items, change [ ] to [x].

NOTE: these things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
