### PR TITLE
Per-object apply options

### DIFF
--- a/controllers/lib/espejote.libsonnet
+++ b/controllers/lib/espejote.libsonnet
@@ -298,6 +298,8 @@ local alpha = {
       The options are:
       - fieldManager: string, the field manager to use when applying the ManagedResource.
         If not set, the field manager is set to the name of the resource with `managed-resource` prefix
+      - fieldManagerSuffix: string, a suffix to append to the field manager.
+        This is useful if different code paths in the template apply differing parts of a resource.
       - force: boolean, is going to "force" Apply requests.
         It means user will re-acquire conflicting fields owned by other people.
       - fieldValidation: string, instructs the managed resource on how to handle
@@ -327,13 +329,14 @@ local alpha = {
             },
           },
         },
-        fieldManager='my-tool-status-reporter',
+        fieldManagerSuffix=':status-reporter',
       )
       ```
     |||,
     [
       d.arg('obj', d.T.object),
       d.arg('fieldManager', d.T.string, null),
+      d.arg('fieldManagerSuffix', d.T.string, null),
       d.arg('force', d.T.boolean, null),
       d.arg('fieldValidation', d.T.string, null),
     ],
@@ -342,6 +345,7 @@ local alpha = {
     function(
       obj,
       fieldManager=null,
+      fieldManagerSuffix=null,
       force=null,
       fieldValidation=null,
     ) obj {
@@ -349,6 +353,7 @@ local alpha = {
       assert std.member(allowedFieldValidation, fieldValidation) : 'fieldValidation must be one of %s, is: %s' % [std.manifestJsonMinified(allowedFieldValidation), fieldValidation],
       __internal_use_espejote_lib_apply_options: std.prune({
         fieldManager: fieldManager,
+        fieldManagerSuffix: fieldManagerSuffix,
         force: force,
         fieldValidation: fieldValidation,
       }),

--- a/controllers/lib/espejote.libsonnet
+++ b/controllers/lib/espejote.libsonnet
@@ -288,4 +288,69 @@ local alpha = {
         preconditionResourceVersion: preconditionResourceVersion,
       }),
     },
+
+  '#applyOptions': d.fn(
+    |||
+      `applyOptions` allows configuring apply options for an object.
+      These options override the `spec.applyOptions` fields of the managed resource.
+
+      The options are used by the controller to determine how to apply the object.
+      The options are:
+      - fieldManager: string, the field manager to use when applying the ManagedResource.
+        If not set, the field manager is set to the name of the resource with `managed-resource` prefix
+      - force: boolean, is going to "force" Apply requests.
+        It means user will re-acquire conflicting fields owned by other people.
+      - fieldValidation: string, instructs the managed resource on how to handle
+        objects containing unknown or duplicate fields. Valid values are:
+        - Ignore: This will ignore any unknown fields that are silently
+        dropped from the object, and will ignore all but the last duplicate
+        field that the decoder encounters.
+        Note that Jsonnet won't allow you to add duplicate fields to an object
+        and most unregistered fields will error out in the server-side apply
+        request, even with this option set.
+        - Strict: This will fail the request with a BadRequest error if
+        any unknown fields would be dropped from the object, or if any
+        duplicate fields are present. The error returned will contain
+        all unknown and duplicate fields encountered.
+        Defaults to "Strict".
+
+      ```jsonnet
+      esp.applyOptions(
+        {
+          apiVersion: 'v1',
+          kind: 'ConfigMap',
+          metadata: {
+            name: 'cm-to-apply-options',
+            namespace: 'target-namespace',
+            annotations: {
+              'my.tool/status': 'Success',
+            },
+          },
+        },
+        fieldManager='my-tool-status-reporter',
+      )
+      ```
+    |||,
+    [
+      d.arg('obj', d.T.object),
+      d.arg('fieldManager', d.T.string, null),
+      d.arg('force', d.T.boolean, null),
+      d.arg('fieldValidation', d.T.string, null),
+    ],
+  ),
+  applyOptions:
+    function(
+      obj,
+      fieldManager=null,
+      force=null,
+      fieldValidation=null,
+    ) obj {
+      local allowedFieldValidation = [null, 'Ignore', 'Strict'],
+      assert std.member(allowedFieldValidation, fieldValidation) : 'fieldValidation must be one of %s, is: %s' % [std.manifestJsonMinified(allowedFieldValidation), fieldValidation],
+      __internal_use_espejote_lib_apply_options: std.prune({
+        fieldManager: fieldManager,
+        force: force,
+        fieldValidation: fieldValidation,
+      }),
+    },
 }

--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -975,16 +975,21 @@ func patchOptionsFromObject(mr espejotev1alpha1.ManagedResource, obj *unstructur
 	}
 
 	fieldManager := mr.Spec.ApplyOptions.FieldManager
-	objFieldOwner, ok, err := unstructured.NestedString(obj.UnstructuredContent(), optionsKey, "fieldManager")
+	objFieldManager, ok, err := unstructured.NestedString(obj.UnstructuredContent(), optionsKey, "fieldManager")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get apply option field owner: %w", err)
+		return nil, fmt.Errorf("failed to get apply option fieldManager: %w", err)
 	}
 	if ok {
-		fieldManager = objFieldOwner
+		fieldManager = objFieldManager
 	}
 	if fieldManager == "" {
 		fieldManager = fmt.Sprintf("managed-resource:%s", mr.GetName())
 	}
+	objFieldManagerSuffix, _, err := unstructured.NestedString(obj.UnstructuredContent(), optionsKey, "fieldManagerSuffix")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apply option fieldManagerSuffix: %w", err)
+	}
+	fieldManager += objFieldManagerSuffix
 
 	po := []client.PatchOption{client.FieldValidation(fieldValidation), client.FieldOwner(fieldManager)}
 

--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -312,7 +312,12 @@ func (r *ManagedResourceReconciler) reconcile(ctx context.Context, req Request) 
 			continue
 		}
 
-		if err := c.Patch(ctx, obj, client.Apply, patchOptionsFromManagedResource(managedResource)...); err != nil {
+		patchOptions, err := patchOptionsFromObject(managedResource, obj)
+		if err != nil {
+			applyErrs = append(applyErrs, fmt.Errorf("failed to get patch options: %w", err))
+			continue
+		}
+		if err := c.Patch(ctx, obj, client.Apply, patchOptions...); err != nil {
 			applyErrs = append(applyErrs, fmt.Errorf("failed to apply object %q %q: %w", obj.GetObjectKind(), obj.GetName(), err))
 		}
 	}
@@ -946,23 +951,58 @@ func wrapNewInformerWithFilter(f func(o client.Object) (keep bool)) func(toolsca
 	}
 }
 
-// patchOptionsFromManagedResource returns the patch options for the given ManagedResource.
-// The options are taken from the ManagedResource's ApplyOptions.
-func patchOptionsFromManagedResource(mr espejotev1alpha1.ManagedResource) []client.PatchOption {
+// patchOptionsFromObject returns the patch options for the given ManagedResource and object.
+// The options are merged from the ManagedResource's ApplyOptions and the object's annotations.
+// Object annotations take precedence over ManagedResource's ApplyOptions.
+// The options are:
+// - FieldValidation: the field validation mode (default: "Strict")
+// - FieldManager: the field manager/owner (default: "managed-resource:<name>")
+// - ForceOwnership: if true, the ownership is forced (default: false)
+// Warning: this function modifies the object by removing the options from the annotations.
+func patchOptionsFromObject(mr espejotev1alpha1.ManagedResource, obj *unstructured.Unstructured) ([]client.PatchOption, error) {
+	const optionsKey = "__internal_use_espejote_lib_apply_options"
+
 	fieldValidation := mr.Spec.ApplyOptions.FieldValidation
+	objFieldValidation, ok, err := unstructured.NestedString(obj.UnstructuredContent(), optionsKey, "fieldValidation")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apply option field validation: %w", err)
+	}
+	if ok {
+		fieldValidation = objFieldValidation
+	}
 	if fieldValidation == "" {
 		fieldValidation = "Strict"
 	}
-	fieldOwner := mr.Spec.ApplyOptions.FieldManager
-	if fieldOwner == "" {
-		fieldOwner = fmt.Sprintf("managed-resource:%s", mr.GetName())
+
+	fieldManager := mr.Spec.ApplyOptions.FieldManager
+	objFieldOwner, ok, err := unstructured.NestedString(obj.UnstructuredContent(), optionsKey, "fieldManager")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apply option field owner: %w", err)
 	}
-	po := []client.PatchOption{client.FieldValidation(fieldValidation), client.FieldOwner(fieldOwner)}
-	if mr.Spec.ApplyOptions.Force {
+	if ok {
+		fieldManager = objFieldOwner
+	}
+	if fieldManager == "" {
+		fieldManager = fmt.Sprintf("managed-resource:%s", mr.GetName())
+	}
+
+	po := []client.PatchOption{client.FieldValidation(fieldValidation), client.FieldOwner(fieldManager)}
+
+	objForce, ok, err := unstructured.NestedBool(obj.UnstructuredContent(), optionsKey, "force")
+	if err != nil {
+		return nil, fmt.Errorf("failed to get apply option force: %w", err)
+	}
+	if ok {
+		if objForce {
+			po = append(po, client.ForceOwnership)
+		}
+	} else if mr.Spec.ApplyOptions.Force {
 		po = append(po, client.ForceOwnership)
 	}
 
-	return po
+	unstructured.RemoveNestedField(obj.UnstructuredContent(), optionsKey)
+
+	return po, nil
 }
 
 // stripUnstructuredForDelete returns a copy of the given unstructured object with only the GroupVersionKind, Namespace and Name set.

--- a/controllers/managedresource_controller_test.go
+++ b/controllers/managedresource_controller_test.go
@@ -719,6 +719,86 @@ local netpols = esp.context().netpols;
 		}, 5*time.Second, 100*time.Millisecond)
 	})
 
+	t.Run("force ownership espejote.libsonnet", func(t *testing.T) {
+		t.Parallel()
+
+		testns := testutil.TmpNamespace(t, c)
+
+		cmToPatch := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testns,
+			},
+			Data: map[string]string{
+				"test": "test",
+			},
+		}
+		const origOwner = "other-owner"
+		require.NoError(t, c.Patch(ctx, cmToPatch, client.Apply, client.FieldOwner(origOwner)))
+
+		mr := &espejotev1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testns,
+			},
+			Spec: espejotev1alpha1.ManagedResourceSpec{
+				Template: `{
+					apiVersion: "v1",
+					kind: "ConfigMap",
+					metadata: {
+						name: "test",
+						namespace: "` + testns + `",
+					},
+					data: {
+						test: "updated",
+					},
+				}`,
+			},
+		}
+		require.NoError(t, c.Create(ctx, mr))
+
+		t.Log("waiting for the conflict event")
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			var events corev1.EventList
+			require.NoError(t, c.List(ctx, &events, client.InNamespace(testns), eventSelectorFor(mr.Name)))
+			require.Len(t, events.Items, 1)
+			assert.Equal(t, "Warning", events.Items[0].Type)
+			assert.Contains(t, events.Items[0].Message, ApplyError)
+			assert.Contains(t, events.Items[0].Message, "conflict")
+			assert.Contains(t, events.Items[0].Message, origOwner)
+			assert.Contains(t, events.Items[0].Message, ".data.test")
+
+			var cm corev1.ConfigMap
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testns, Name: "test"}, &cm))
+			assert.Equal(t, "test", cm.Data["test"])
+		}, 5*time.Second, 100*time.Millisecond)
+
+		t.Log("force updating the resource and waiting for a successful update")
+		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(mr), mr))
+		mr.Spec.Template = `(import "espejote.libsonnet").applyOptions({
+					apiVersion: "v1",
+					kind: "ConfigMap",
+					metadata: {
+						name: "test",
+						namespace: "` + testns + `",
+					},
+					data: {
+						test: "updated",
+					},
+				}, force=true)`
+		require.NoError(t, c.Update(ctx, mr))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			var cm corev1.ConfigMap
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testns, Name: "test"}, &cm))
+			assert.Equal(t, "updated", cm.Data["test"])
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
 	t.Run("override field manager", func(t *testing.T) {
 		t.Parallel()
 
@@ -789,6 +869,86 @@ local netpols = esp.context().netpols;
 		}, 5*time.Second, 100*time.Millisecond)
 	})
 
+	t.Run("override field manager espejote.libsonnet", func(t *testing.T) {
+		t.Parallel()
+
+		testns := testutil.TmpNamespace(t, c)
+
+		cmToPatch := &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testns,
+			},
+			Data: map[string]string{
+				"test": "test",
+			},
+		}
+		const origOwner = "other-owner"
+		require.NoError(t, c.Patch(ctx, cmToPatch, client.Apply, client.FieldOwner(origOwner)))
+
+		mr := &espejotev1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testns,
+			},
+			Spec: espejotev1alpha1.ManagedResourceSpec{
+				Template: `{
+					apiVersion: "v1",
+					kind: "ConfigMap",
+					metadata: {
+						name: "test",
+						namespace: "` + testns + `",
+					},
+					data: {
+						test: "updated",
+					},
+				}`,
+			},
+		}
+		require.NoError(t, c.Create(ctx, mr))
+
+		t.Log("waiting for the conflict event")
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			var events corev1.EventList
+			require.NoError(t, c.List(ctx, &events, client.InNamespace(testns), eventSelectorFor(mr.Name)))
+			require.Len(t, events.Items, 1)
+			assert.Equal(t, "Warning", events.Items[0].Type)
+			assert.Contains(t, events.Items[0].Message, ApplyError)
+			assert.Contains(t, events.Items[0].Message, "conflict")
+			assert.Contains(t, events.Items[0].Message, origOwner)
+			assert.Contains(t, events.Items[0].Message, ".data.test")
+
+			var cm corev1.ConfigMap
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testns, Name: "test"}, &cm))
+			assert.Equal(t, "test", cm.Data["test"])
+		}, 5*time.Second, 100*time.Millisecond)
+
+		t.Log("changing the field manager to the original field manager and waiting for a successful update")
+		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(mr), mr))
+		mr.Spec.Template = `(import "espejote.libsonnet").applyOptions({
+					apiVersion: "v1",
+					kind: "ConfigMap",
+					metadata: {
+						name: "test",
+						namespace: "` + testns + `",
+					},
+					data: {
+						test: "updated",
+					},
+				}, fieldManager="` + origOwner + `")`
+		require.NoError(t, c.Update(ctx, mr))
+
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			var cm corev1.ConfigMap
+			require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: testns, Name: "test"}, &cm))
+			assert.Equal(t, "updated", cm.Data["test"])
+		}, 5*time.Second, 100*time.Millisecond)
+	})
+
 	t.Run("field validation Ignore", func(t *testing.T) {
 		t.Parallel()
 		t.Log("field validation Ignore seems to have no effect on the apply process. This test is here to document this behavior and see if the behavior changes in the future.")
@@ -831,6 +991,67 @@ local netpols = esp.context().netpols;
 		t.Log("ignoring dropped field and waiting for a successful update")
 		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(mr), mr))
 		mr.Spec.ApplyOptions.FieldValidation = "Ignore"
+		require.NoError(t, c.Update(ctx, mr))
+
+		// Error should always be IsNotFound, see head of test as for why
+		require.Never(t, func() bool {
+			return !apierrors.IsNotFound(c.Get(ctx, types.NamespacedName{Namespace: testns, Name: "test"}, new(corev1.ConfigMap)))
+		}, 2*time.Second, 100*time.Millisecond)
+	})
+
+	t.Run("field validation Ignore espejote.libsonnet", func(t *testing.T) {
+		t.Parallel()
+		t.Log("field validation Ignore seems to have no effect on the apply process. This test is here to document this behavior and see if the behavior changes in the future.")
+
+		testns := testutil.TmpNamespace(t, c)
+
+		mr := &espejotev1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: testns,
+			},
+			Spec: espejotev1alpha1.ManagedResourceSpec{
+				Template: `{
+					apiVersion: "v1",
+					kind: "ConfigMap",
+					metadata: {
+						name: "test",
+						namespace: "` + testns + `",
+					},
+					data: {
+						test: "test",
+					},
+					typo: "what what",
+				}`,
+			},
+		}
+		require.NoError(t, c.Create(ctx, mr))
+
+		t.Log("waiting for the validation error event")
+		require.EventuallyWithT(t, func(t *assert.CollectT) {
+			var events corev1.EventList
+			require.NoError(t, c.List(ctx, &events, client.InNamespace(testns), eventSelectorFor(mr.Name)))
+			require.Len(t, events.Items, 1)
+			assert.Equal(t, "Warning", events.Items[0].Type)
+			assert.Contains(t, events.Items[0].Message, ApplyError)
+			assert.Contains(t, events.Items[0].Message, ".typo")
+			assert.Contains(t, events.Items[0].Message, "field not declared")
+		}, 5*time.Second, 100*time.Millisecond)
+
+		t.Log("ignoring dropped field and waiting for a successful update")
+		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(mr), mr))
+		mr.Spec.Template = `(import "espejote.libsonnet").applyOptions({
+					apiVersion: "v1",
+					kind: "ConfigMap",
+					metadata: {
+						name: "test",
+						namespace: "` + testns + `",
+					},
+					data: {
+						test: "test",
+					},
+					typo: "what what",
+				}, fieldValidation="Ignore")`
 		require.NoError(t, c.Update(ctx, mr))
 
 		// Error should always be IsNotFound, see head of test as for why

--- a/docs/lib/README.md
+++ b/docs/lib/README.md
@@ -12,6 +12,7 @@ local espejote = import "espejote.libsonnet"
 
 ## Index
 
+* [`fn applyOptions(obj, fieldManager, force, fieldValidation)`](#fn-applyoptions)
 * [`fn context()`](#fn-context)
 * [`fn markForDelete(obj, gracePeriodSeconds, propagationPolicy, preconditionUID, preconditionResourceVersion)`](#fn-markfordelete)
 * [`fn triggerData()`](#fn-triggerdata)
@@ -26,6 +27,53 @@ local espejote = import "espejote.libsonnet"
     * [`fn patched(msg, patches)`](#fn-alphaadmissionpatched)
 
 ## Fields
+
+### fn applyOptions
+
+```ts
+applyOptions(obj, fieldManager, force, fieldValidation)
+```
+
+`applyOptions` allows configuring apply options for an object.
+These options override the `spec.applyOptions` fields of the managed resource.
+
+The options are used by the controller to determine how to apply the object.
+The options are:
+- fieldManager: string, the field manager to use when applying the ManagedResource.
+  If not set, the field manager is set to the name of the resource with `managed-resource` prefix
+- force: boolean, is going to "force" Apply requests.
+  It means user will re-acquire conflicting fields owned by other people.
+- fieldValidation: string, instructs the managed resource on how to handle
+  objects containing unknown or duplicate fields. Valid values are:
+  - Ignore: This will ignore any unknown fields that are silently
+  dropped from the object, and will ignore all but the last duplicate
+  field that the decoder encounters.
+  Note that Jsonnet won't allow you to add duplicate fields to an object
+  and most unregistered fields will error out in the server-side apply
+  request, even with this option set.
+  - Strict: This will fail the request with a BadRequest error if
+  any unknown fields would be dropped from the object, or if any
+  duplicate fields are present. The error returned will contain
+  all unknown and duplicate fields encountered.
+  Defaults to "Strict".
+
+```jsonnet
+esp.applyOptions(
+  {
+    apiVersion: 'v1',
+    kind: 'ConfigMap',
+    metadata: {
+      name: 'cm-to-apply-options',
+      namespace: 'target-namespace',
+      annotations: {
+        'my.tool/status': 'Success',
+      },
+    },
+  },
+  fieldManager='my-tool-status-reporter',
+)
+```
+
 
 ### fn context
 

--- a/docs/lib/README.md
+++ b/docs/lib/README.md
@@ -12,7 +12,7 @@ local espejote = import "espejote.libsonnet"
 
 ## Index
 
-* [`fn applyOptions(obj, fieldManager, force, fieldValidation)`](#fn-applyoptions)
+* [`fn applyOptions(obj, fieldManager, fieldManagerSuffix, force, fieldValidation)`](#fn-applyoptions)
 * [`fn context()`](#fn-context)
 * [`fn markForDelete(obj, gracePeriodSeconds, propagationPolicy, preconditionUID, preconditionResourceVersion)`](#fn-markfordelete)
 * [`fn triggerData()`](#fn-triggerdata)
@@ -31,7 +31,7 @@ local espejote = import "espejote.libsonnet"
 ### fn applyOptions
 
 ```ts
-applyOptions(obj, fieldManager, force, fieldValidation)
+applyOptions(obj, fieldManager, fieldManagerSuffix, force, fieldValidation)
 ```
 
 `applyOptions` allows configuring apply options for an object.
@@ -41,6 +41,8 @@ The options are used by the controller to determine how to apply the object.
 The options are:
 - fieldManager: string, the field manager to use when applying the ManagedResource.
   If not set, the field manager is set to the name of the resource with `managed-resource` prefix
+- fieldManagerSuffix: string, a suffix to append to the field manager.
+  This is useful if different code paths in the template apply differing parts of a resource.
 - force: boolean, is going to "force" Apply requests.
   It means user will re-acquire conflicting fields owned by other people.
 - fieldValidation: string, instructs the managed resource on how to handle
@@ -70,7 +72,7 @@ esp.applyOptions(
       },
     },
   },
-  fieldManager='my-tool-status-reporter',
+  fieldManagerSuffix=':status-reporter',
 )
 ```
 


### PR DESCRIPTION
This primarily helps with cases where the same object is updated from two different code paths.

In the example below the second patch would delete the `importantKey` of the first one without the different field manager.

```jsonnet
local esp = import "espejote.libsonnet";

[
  {
    apiVersion: 'v1',
    kind: 'ConfigMap',
    metadata: {
      name: 'example-config',
    },
    data: {
      importantKey: 'importantValue',
    },
  },
  esp.applyOptions({
    apiVersion: 'v1',
    kind: 'ConfigMap',
    metadata: {
      name: 'example-config',
      annotations: {
        'my.tool/key-status': 'managed',
      },
    },
  }, fieldManagerSuffix=':status-manager'),
]
```

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
