### PR TITLE
Allow concurrent reconciles

### DIFF
--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -521,12 +521,12 @@ func (r *ManagedResourceReconciler) cacheFor(ctx context.Context, mr espejotev1a
 }
 
 // Setup sets up the controller with the Manager.
-func (r *ManagedResourceReconciler) Setup(cfg *rest.Config, mgr ctrl.Manager) error {
-	return r.SetupWithName(cfg, mgr, "managed_resource")
+func (r *ManagedResourceReconciler) Setup(cfg *rest.Config, mgr ctrl.Manager, maxConcurrentReconciles int) error {
+	return r.SetupWithName(cfg, mgr, "managed_resource", maxConcurrentReconciles)
 }
 
 // SetupWithName sets up the controller with the Manager and a name for the global metrics registry.
-func (r *ManagedResourceReconciler) SetupWithName(cfg *rest.Config, mgr ctrl.Manager, name string) error {
+func (r *ManagedResourceReconciler) SetupWithName(cfg *rest.Config, mgr ctrl.Manager, name string, maxConcurrentReconciles int) error {
 	c, err := builder.TypedControllerManagedBy[Request](mgr).
 		Named(name).
 		Watches(&espejotev1alpha1.ManagedResource{}, handler.TypedEnqueueRequestsFromMapFunc(func(ctx context.Context, a client.Object) []Request {
@@ -539,6 +539,9 @@ func (r *ManagedResourceReconciler) SetupWithName(cfg *rest.Config, mgr ctrl.Man
 				},
 			}
 		})).
+		WithOptions(controller.TypedOptions[Request]{
+			MaxConcurrentReconciles: maxConcurrentReconciles,
+		}).
 		Build(r)
 	if err != nil {
 		return fmt.Errorf("failed to setup controller: %w", err)

--- a/docs/cli/espejote_controller.md
+++ b/docs/cli/espejote_controller.md
@@ -22,6 +22,7 @@ espejote controller [flags]
   -h, --help                                            help for controller
       --jsonnet-library-namespace lib/                  The namespace to look for shared (lib/) Jsonnet libraries in. (default "default")
       --leader-elect                                    Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.
+      --max-concurrent-reconciles int                   The maximum number of concurrent reconciles that the controller manager will run.  (default 10)
       --metrics-bind-address string                     The address the metric endpoint binds to. (default ":8080")
       --metrics-cert-key string                         The name of the metrics server key file. (default "tls.key")
       --metrics-cert-name string                        The name of the metrics server certificate file. (default "tls.crt")


### PR DESCRIPTION
The normal controller-runtime guarantees apply - no unique combination of trigger and managed resource is reconciled in parallel.

Test was updated to not flake out if two triggers want to update the resource status. 

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
