### PR TITLE
Fewer `Admission` reconciles

### DIFF
--- a/controllers/admission_controller_test.go
+++ b/controllers/admission_controller_test.go
@@ -4,27 +4,53 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	espejotev1alpha1 "github.com/vshn/espejote/api/v1alpha1"
 	"github.com/vshn/espejote/testutil"
 )
 
 func Test_AdmissionReconciler_Reconcile(t *testing.T) {
-	t.Parallel()
+	const webhookName = "espejote-webhook"
 
 	scheme, cfg := testutil.SetupEnvtestEnv(t)
 	c, err := client.NewWithWatch(cfg, client.Options{
 		Scheme: scheme,
 	})
 	require.NoError(t, err)
+
+	ctx := log.IntoContext(t.Context(), testr.New(t))
+
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: scheme,
+		Logger: testr.New(t),
+	})
+	require.NoError(t, err)
+	subject := &AdmissionReconciler{
+		Client:                c,
+		MutatingWebhookName:   webhookName,
+		ValidatingWebhookName: webhookName,
+		WebhookPort:           9443,
+		WebhookServiceName:    webhookName,
+		ControllerNamespace:   "system",
+	}
+	require.NoError(t, subject.SetupWithManager(mgr))
+
+	mgrCtx, mgrCancel := context.WithCancel(ctx)
+	t.Cleanup(mgrCancel)
+	go func() {
+		require.NoError(t, mgr.Start(mgrCtx))
+	}()
 
 	testns := testutil.TmpNamespace(t, c)
 
@@ -51,7 +77,18 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 			},
 		},
 	}
-	require.NoError(t, c.Create(context.Background(), &val))
+	require.NoError(t, c.Create(ctx, &val))
+	val2 := espejotev1alpha1.Admission{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "zz-val",
+			Namespace: testns,
+		},
+		Spec: espejotev1alpha1.AdmissionSpec{
+			Mutating:             false,
+			WebhookConfiguration: *val.Spec.WebhookConfiguration.DeepCopy(),
+		},
+	}
+	require.NoError(t, c.Create(ctx, &val2))
 	mut := espejotev1alpha1.Admission{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "mut",
@@ -62,23 +99,13 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 			WebhookConfiguration: *val.Spec.WebhookConfiguration.DeepCopy(),
 		},
 	}
-	require.NoError(t, c.Create(context.Background(), &mut))
-
-	subject := &AdmissionReconciler{
-		Client:                c,
-		MutatingWebhookName:   "espejote-webhook",
-		ValidatingWebhookName: "espejote-webhook",
-		WebhookPort:           9443,
-		WebhookServiceName:    "espejote-webhook",
-		ControllerNamespace:   "system",
-	}
-
-	_, err = subject.Reconcile(context.Background(), reconcile.Request{})
-	require.NoError(t, err)
+	require.NoError(t, c.Create(ctx, &mut))
 
 	var mutwebhook admissionregistrationv1.MutatingWebhookConfiguration
-	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "espejote-webhook"}, &mutwebhook))
-	require.Len(t, mutwebhook.Webhooks, 1)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Name: webhookName}, &mutwebhook))
+		require.Len(t, mutwebhook.Webhooks, 1)
+	}, 5*time.Second, 10*time.Millisecond)
 	assert.Equal(t, strings.Join([]string{"mut", testns, "espejote.io"}, "."), mutwebhook.Webhooks[0].Name)
 	assert.Equal(t, "system", mutwebhook.Webhooks[0].ClientConfig.Service.Namespace)
 	assert.Equal(t, strings.Join([]string{"/dynamic", testns, "mut"}, "/"), *mutwebhook.Webhooks[0].ClientConfig.Service.Path)
@@ -86,11 +113,34 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	assert.Equal(t, map[string]string{"kubernetes.io/metadata.name": testns}, mutwebhook.Webhooks[0].NamespaceSelector.MatchLabels)
 
 	var valwebhook admissionregistrationv1.ValidatingWebhookConfiguration
-	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "espejote-webhook"}, &valwebhook))
-	require.Len(t, valwebhook.Webhooks, 1)
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Name: webhookName}, &valwebhook))
+		require.Len(t, valwebhook.Webhooks, 2)
+	}, 5*time.Second, 10*time.Millisecond)
 	assert.Equal(t, strings.Join([]string{"val", testns, "espejote.io"}, "."), valwebhook.Webhooks[0].Name)
 	assert.Equal(t, "system", valwebhook.Webhooks[0].ClientConfig.Service.Namespace)
 	assert.Equal(t, strings.Join([]string{"/dynamic", testns, "val"}, "/"), *valwebhook.Webhooks[0].ClientConfig.Service.Path)
 	assert.Equal(t, ptr.To(int32(subject.WebhookPort)), valwebhook.Webhooks[0].ClientConfig.Service.Port)
 	assert.Equal(t, map[string]string{"kubernetes.io/metadata.name": testns}, valwebhook.Webhooks[0].NamespaceSelector.MatchLabels)
+
+	require.NoError(t, c.Delete(ctx, &val2))
+	require.NoError(t, c.Delete(ctx, &mut))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Name: webhookName}, &valwebhook))
+		require.Len(t, valwebhook.Webhooks, 1)
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Name: webhookName}, &mutwebhook))
+		require.Len(t, mutwebhook.Webhooks, 0)
+	}, 5*time.Second, 10*time.Millisecond)
+
+	require.NoError(t, c.Delete(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhookName,
+		},
+	}))
+
+	require.EventuallyWithT(t, func(t *assert.CollectT) {
+		require.NoError(t, c.Get(ctx, client.ObjectKey{Name: webhookName}, &valwebhook))
+		require.Len(t, valwebhook.Webhooks, 1)
+	}, 5*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
Every request does the same, no matter the concrete resource, so we can simplify to a single queue element.

Makes the code easier and leads to less reconciles.

Also fixes an issue where undefined webhook sort order could lead to unnecessary resource updates.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
