### PR TITLE
Attach raw event from watch resource to trigger data

### DIFF
--- a/controllers/lib/espejote.libsonnet
+++ b/controllers/lib/espejote.libsonnet
@@ -231,7 +231,9 @@ local alpha = {
   '#triggerData': d.fn(|||
     Gets data added to the trigger by the controller.
     Currently only available for WatchResource triggers.
-    WatchResource triggers add the full object that triggered the template to the trigger data under the key `resource`.
+    WatchResource triggers add the full object that triggered the template to the trigger data under the key `resource` and
+    the raw trigger event - a flat dictionary consisting of `apiVersion`, `kind`, `name`, and `namespace` - under the key `resourceEvent`.
+    The `resource` object might be null if the object was deleted and can't be retrieved.
   |||),
   triggerData: function() std.get(trigger, 'data'),
 

--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -558,6 +558,18 @@ func (r *Renderer) renderTriggers(ctx context.Context, getReader func(string) (c
 	}
 
 	if ti.WatchResource != (WatchResource{}) {
+		triggerData := struct {
+			Resource map[string]any `json:"resource"`
+			Event    map[string]any `json:"resourceEvent"`
+		}{
+			Event: map[string]any{
+				"apiVersion": schema.GroupVersion{Group: ti.WatchResource.Group, Version: ti.WatchResource.APIVersion}.String(),
+				"kind":       ti.WatchResource.Kind,
+				"name":       ti.WatchResource.Name,
+				"namespace":  ti.WatchResource.Namespace,
+			},
+		}
+
 		var triggerObj unstructured.Unstructured
 		triggerObj.SetGroupVersionKind(schema.GroupVersionKind{
 			Group:   ti.WatchResource.Group,
@@ -570,20 +582,18 @@ func (r *Renderer) renderTriggers(ctx context.Context, getReader func(string) (c
 		}
 		err = reader.Get(ctx, types.NamespacedName{Namespace: ti.WatchResource.Namespace, Name: ti.WatchResource.Name}, &triggerObj)
 		if err == nil {
-			triggerJSONBytes, err := json.Marshal(struct {
-				Resource map[string]any `json:"resource"`
-			}{
-				Resource: triggerObj.UnstructuredContent(),
-			})
-			if err != nil {
-				return "", fmt.Errorf("failed to marshal trigger info: %w", err)
-			}
-			triggerInfo.Data = triggerJSONBytes
+			triggerData.Resource = triggerObj.UnstructuredContent()
 		} else if apierrors.IsNotFound(err) {
 			log.FromContext(ctx).WithValues("trigger", ti.WatchResource).Info("trigger object not found, was deleted")
 		} else {
 			return "", fmt.Errorf("failed to get trigger object: %w", err)
 		}
+
+		dataJSON, err := json.Marshal(triggerData)
+		if err != nil {
+			return "", fmt.Errorf("failed to marshal trigger data: %w", err)
+		}
+		triggerInfo.Data = dataJSON
 	}
 
 	triggerJSON, err := json.Marshal(triggerInfo)

--- a/docs/lib/README.md
+++ b/docs/lib/README.md
@@ -121,7 +121,9 @@ triggerData()
 
 Gets data added to the trigger by the controller.
 Currently only available for WatchResource triggers.
-WatchResource triggers add the full object that triggered the template to the trigger data under the key `resource`.
+WatchResource triggers add the full object that triggered the template to the trigger data under the key `resource` and
+the raw trigger event - a flat dictionary consisting of `apiVersion`, `kind`, `name`, and `namespace` - under the key `resourceEvent`.
+The `resource` object might be null if the object was deleted and can't be retrieved.
 
 
 ### fn triggerName


### PR DESCRIPTION
Allows reacting to deleted resources which can be impossible otherwise. Note that reacting to deleted resources might still be a bad idea as you might not get any deletion events. (That's what finalizers are for.)

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
