### PR TITLE
Add first contrib (non-core) jsonnet libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,12 @@ testbin/*
 Dockerfile.cross
 espejote
 
+contrib/lib/vendor
+
 # Goreleaser
 dist/
 .github/release-notes.md
-contrib/
+contrib/completion
 
 # Test binary, build with `go test -c`
 *.test

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MAKEFLAGS += --no-builtin-variables
 
 export GOEXPERIMENT = jsonv2
 
-JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
+JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' -not -path './contrib/lib/vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
 
 include Makefile.vars.mk
 
@@ -29,10 +29,15 @@ completions:
 	go run ./tools/completions fish > contrib/completion/fish/espejote
 	go run ./tools/completions zsh > contrib/completion/zsh/_espejote
 
+.PHONY: test-contrib
+test-contrib: ## Run tests for the contrib library
+	(cd contrib/lib && ./test.sh)
+
 .PHONY: test
 test: manifests generate ## Run tests
 	KUBEBUILDER_ASSETS="$(shell go tool sigs.k8s.io/controller-runtime/tools/setup-envtest use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./... -race -coverprofile cover.tmp.out
 	cat cover.tmp.out | grep -v "zz_generated.deepcopy.go" > cover.out
+	$(MAKE) test-contrib
 
 .PHONY: build
 build: generate manifests fmt vet $(BIN_FILENAME) ## Build manager binary
@@ -40,12 +45,17 @@ build: generate manifests fmt vet $(BIN_FILENAME) ## Build manager binary
 .PHONY: manifests
 manifests: ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	go tool sigs.k8s.io/controller-tools/cmd/controller-gen rbac:roleName=manager-role crd:generateEmbeddedObjectMeta=true webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	@echo "Updating contrib-jsonnetlibrary.yaml with the contents of contrib/lib/*.libsonnet ..."
+	yq -i '.spec.data = {}' config/contrib/contrib-jsonnetlibrary.yaml
+	for f in contrib/lib/*.libsonnet ; do fn=$$(basename $$f) fv=$$(cat $$f) yq -i '.spec.data[strenv(fn)] = strenv(fv)' config/contrib/contrib-jsonnetlibrary.yaml ; done
 
 .PHONY: docs
 docs: ## Generate documentation
 	go tool github.com/elastic/crd-ref-docs --config=crd-ref-docs-config.yaml --source-path=api/v1alpha1 --output-path docs/api.adoc
 	FORCE_COLOR=1 go run ./tools/genclidoc ./docs/cli
 	go tool github.com/jsonnet-libs/docsonnet controllers/lib/espejote.libsonnet -o docs/lib
+	rm -rf docs/contrib/lib && mkdir -p docs/contrib/lib
+	for f in contrib/lib/*.libsonnet ; do go tool github.com/jsonnet-libs/docsonnet $$f -o docs/contrib/lib/$$(basename $$f) ; done
 
 .PHONY: generate
 generate: ## Generate manifests e.g. CRD, RBAC etc.
@@ -75,7 +85,7 @@ build.docker: $(BIN_FILENAME) ## Build the docker image
 		--tag $(GHCR_IMG)
 
 clean: ## Cleans up the generated resources
-	rm -rf contrib/ dist/ cover.out $(BIN_FILENAME) || true
+	rm -rf contrib/completion dist/ cover.out $(BIN_FILENAME) ||:
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.

--- a/config/contrib/contrib-jsonnetlibrary.yaml
+++ b/config/contrib/contrib-jsonnetlibrary.yaml
@@ -1,0 +1,177 @@
+apiVersion: espejote.io/v1alpha1
+kind: JsonnetLibrary
+metadata:
+  annotations:
+    description: |
+      A collection of Jsonnet utilities and helper functions that don't fit into the espejote core library, but are still generally useful for writing Jsonnet code for espejote.
+
+      Documentation is available in the `docs/contrib/lib` directory.
+  labels:
+    app.kubernetes.io/name: espejote
+    app.kubernetes.io/managed-by: kustomize
+  name: contrib
+spec:
+  data:
+    accessors.libsonnet: |-
+      local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+      {
+        '#': d.pkg(
+          name='accessors',
+          url='accessors.libsonnet',
+          help='`accessors` implements accessors for Kubernetes manifests/ objects.',
+        ),
+
+        '#inDelete': d.fn(|||
+          Checks if an object is in the process of being deleted.
+        |||, [
+          d.arg('obj', d.T.object),
+        ]),
+        inDelete: function(obj) std.get(std.get(obj, 'metadata', {}), 'deletionTimestamp', '') != '',
+
+        '#getName': d.fn(|||
+          Gets the name of an object. Empty string is returned if the name is not set.
+        |||, [
+          d.arg('obj', d.T.object),
+        ]),
+        getName: function(obj) std.get(std.get(obj, 'metadata', {}), 'name', ''),
+
+        '#getNamespace': d.fn(|||
+          Gets the namespace of an object. Empty string is returned if the namespace is not set.
+        |||, [
+          d.arg('obj', d.T.object),
+        ]),
+        getNamespace: function(obj) std.get(std.get(obj, 'metadata', {}), 'namespace', ''),
+
+        '#getLabel': d.fn(|||
+          Gets the value of a label from an object. Null is returned if the label is not set.
+        |||, [
+          d.arg('obj', d.T.object),
+          d.arg('label', d.T.string),
+        ]),
+        getLabel: function(obj, label) std.get(std.get(std.get(obj, 'metadata', {}), 'labels', {}), label, null),
+
+        '#getAnnotation': d.fn(|||
+          Gets the value of an annotation from an object. Null is returned if the annotation is not set.
+        |||, [
+          d.arg('obj', d.T.object),
+          d.arg('annotation', d.T.string),
+        ]),
+        getAnnotation: function(obj, annotation) std.get(std.get(std.get(obj, 'metadata', {}), 'annotations', {}), annotation, null),
+      }
+    errors.libsonnet: |-
+      local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+      local result = {
+        local this = self,
+        '#unwrap': d.fn(|||
+          Unwraps the result, returning the contained value if it's `ok`, or throwing an error if it's `err`.
+        |||),
+        unwrap: function()
+          if this._type == 'ok' then
+            this._result
+          else
+            error this._error
+        ,
+        '#unwrapOr': d.fn(|||
+          Unwraps the result, returning the contained value if it's `ok`, or returning a default value if it's `err`.
+        |||, [
+          d.arg('or', d.T.any),
+        ]),
+        unwrapOr: function(or)
+          if this._type == 'ok' then
+            this._result
+          else
+            or
+        ,
+        '#match': d.fn(|||
+          Matches on the result, calling `ok(value)` if it's `ok`, or `err(error)` if it's `err`.
+
+          A new result can be returned from the match functions to chain operations, or any value can be returned to break the chain.
+          Both functions can be omitted.
+          `ok` defaults to returning a ok result with the value, and `err` defaults to returning an err result with the error message.
+        |||, [
+          d.arg('ok', d.T.func),
+          d.arg('err', d.T.func),
+        ]),
+        match: function(
+          ok=function(res) result {
+            _result: res,
+            _type: 'ok',
+          }, err=function(msg) result {
+            _error: msg,
+            _type: 'error',
+          }
+              )
+          if this._type == 'ok' then
+            ok(this._result)
+          else
+            err(this._error),
+      };
+
+      local ok(any) = result {
+        _result: any,
+        _type: 'ok',
+      };
+
+      local err(msg) = result {
+        _error: msg,
+        _type: 'error',
+      };
+
+      {
+        '#': d.pkg(
+          name='errors',
+          url='errors.libsonnet',
+          help=|||
+            `errors` Implements error handling utilities.
+
+            Jsonnet errors immediately terminate the program, which makes it difficult to handle errors gracefully.
+            This library provides a `result` type that can be used to represent either a successful result or an error,
+            allowing you to handle errors without crashing the entire program.
+
+            It is inspired by Rust's `Result` type.
+
+            ```jsonnet
+            local errors = import 'errors.libsonnet';
+
+            local divide = function(a, b)
+              if b == 0 then
+                errors.err('division by zero')
+              else
+                errors.ok(a / b)
+              ;
+
+            local result1 = divide(10, 2); // ok(5)
+            local result2 = divide(10, 0); // err('division by zero')
+
+            local value1 = result1.unwrapOr(0); // 5
+            local value2 = result2.unwrapOr(0); // 0
+
+            local value1 = result1.unwrap(); // 5
+            local value2 = result2.unwrap(); // throws an error with message 'division by zero'
+
+            local message1 = result1.match(
+              ok=function(value) 'Result is ' + std.toString(value),
+              err=function(msg) 'Error: ' + msg,
+            ); // 'Result is 5'
+            ```
+          |||,
+        ),
+        '#ok': d.fn(|||
+          Ok creates a successful result containing the given value.
+        |||, [
+          d.arg('any', d.T.any),
+        ]),
+        ok: ok,
+        '#err': d.fn(|||
+          Err creates an error result containing the given error message.
+        |||, [
+          d.arg('msg', d.T.string),
+        ]),
+        err: err,
+        '#result': d.obj(
+          'A result can be either a successful value or an error message. It provides methods to handle both cases. Should be created using `ok` or `err` functions.',
+        ),
+        result: result,
+      }

--- a/config/contrib/kustomization.yaml
+++ b/config/contrib/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - contrib-jsonnetlibrary.yaml

--- a/contrib/lib/accessors.libsonnet
+++ b/contrib/lib/accessors.libsonnet
@@ -1,0 +1,46 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+{
+  '#': d.pkg(
+    name='accessors',
+    url='accessors.libsonnet',
+    help='`accessors` implements accessors for Kubernetes manifests/ objects.',
+  ),
+
+  '#inDelete': d.fn(|||
+    Checks if an object is in the process of being deleted.
+  |||, [
+    d.arg('obj', d.T.object),
+  ]),
+  inDelete: function(obj) std.get(std.get(obj, 'metadata', {}), 'deletionTimestamp', '') != '',
+
+  '#getName': d.fn(|||
+    Gets the name of an object. Empty string is returned if the name is not set.
+  |||, [
+    d.arg('obj', d.T.object),
+  ]),
+  getName: function(obj) std.get(std.get(obj, 'metadata', {}), 'name', ''),
+
+  '#getNamespace': d.fn(|||
+    Gets the namespace of an object. Empty string is returned if the namespace is not set.
+  |||, [
+    d.arg('obj', d.T.object),
+  ]),
+  getNamespace: function(obj) std.get(std.get(obj, 'metadata', {}), 'namespace', ''),
+
+  '#getLabel': d.fn(|||
+    Gets the value of a label from an object. Null is returned if the label is not set.
+  |||, [
+    d.arg('obj', d.T.object),
+    d.arg('label', d.T.string),
+  ]),
+  getLabel: function(obj, label) std.get(std.get(std.get(obj, 'metadata', {}), 'labels', {}), label, null),
+
+  '#getAnnotation': d.fn(|||
+    Gets the value of an annotation from an object. Null is returned if the annotation is not set.
+  |||, [
+    d.arg('obj', d.T.object),
+    d.arg('annotation', d.T.string),
+  ]),
+  getAnnotation: function(obj, annotation) std.get(std.get(std.get(obj, 'metadata', {}), 'annotations', {}), annotation, null),
+}

--- a/contrib/lib/accessors_test.jsonnet
+++ b/contrib/lib/accessors_test.jsonnet
@@ -1,0 +1,62 @@
+local accessors = import 'accessors.libsonnet';
+local JSONNETUNIT = import 'github.com/bastjan/jsonnunit/lib/jsonnunit.libsonnet';
+
+JSONNETUNIT.describe(
+  'inDelete',
+  JSONNETUNIT.it(
+    'should return true if deletionTimestamp is set',
+    JSONNETUNIT.expect(accessors.inDelete({ metadata: { deletionTimestamp: '2024-01-01T00:00:00Z' } })).to.be['true']
+  ).it(
+    'should return false if deletionTimestamp is not set', [
+      JSONNETUNIT.expect(accessors.inDelete({})).to.be['false'],
+      JSONNETUNIT.expect(accessors.inDelete({ metadata: {} })).to.be['false'],
+      JSONNETUNIT.expect(accessors.inDelete({ metadata: { deletionTimestamp: '' } })).to.be['false'],
+    ],
+  )
+).describe(
+  'getName',
+  JSONNETUNIT.it(
+    'should return the name of the object',
+    JSONNETUNIT.expect(accessors.getName({ metadata: { name: 'my-object' } })).to.equal('my-object')
+  ).it(
+    'should return empty string if name is not set', [
+      JSONNETUNIT.expect(accessors.getName({ metadata: {} })).to.equal(''),
+      JSONNETUNIT.expect(accessors.getName({})).to.equal(''),
+    ],
+  )
+).describe(
+  'getNamespace',
+  JSONNETUNIT.it(
+    'should return the namespace of the object',
+    JSONNETUNIT.expect(accessors.getNamespace({ metadata: { namespace: 'my-namespace' } })).to.equal('my-namespace')
+  ).it(
+    'should return empty string if namespace is not set', [
+      JSONNETUNIT.expect(accessors.getNamespace({ metadata: {} })).to.equal(''),
+      JSONNETUNIT.expect(accessors.getNamespace({})).to.equal(''),
+    ],
+  )
+).describe(
+  'getLabel',
+  JSONNETUNIT.it(
+    'should return the value of a label',
+    JSONNETUNIT.expect(accessors.getLabel({ metadata: { labels: { app: 'my-app' } } }, 'app')).to.equal('my-app')
+  ).it(
+    'should return null if label is not set', [
+      JSONNETUNIT.expect(accessors.getLabel({ metadata: { labels: {} } }, 'app')).to.be['null'],
+      JSONNETUNIT.expect(accessors.getLabel({ metadata: {} }, 'app')).to.be['null'],
+      JSONNETUNIT.expect(accessors.getLabel({}, 'app')).to.be['null'],
+    ],
+  )
+).describe(
+  'getAnnotation',
+  JSONNETUNIT.it(
+    'should return the value of an annotation',
+    JSONNETUNIT.expect(accessors.getAnnotation({ metadata: { annotations: { description: 'my-object' } } }, 'description')).to.equal('my-object')
+  ).it(
+    'should return null if annotation is not set', [
+      JSONNETUNIT.expect(accessors.getAnnotation({ metadata: { annotations: {} } }, 'description')).to.be['null'],
+      JSONNETUNIT.expect(accessors.getAnnotation({ metadata: {} }, 'description')).to.be['null'],
+      JSONNETUNIT.expect(accessors.getAnnotation({}, 'description')).to.be['null'],
+    ],
+  )
+)

--- a/contrib/lib/errors.libsonnet
+++ b/contrib/lib/errors.libsonnet
@@ -1,0 +1,115 @@
+local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
+
+local result = {
+  local this = self,
+  '#unwrap': d.fn(|||
+    Unwraps the result, returning the contained value if it's `ok`, or throwing an error if it's `err`.
+  |||),
+  unwrap: function()
+    if this._type == 'ok' then
+      this._result
+    else
+      error this._error
+  ,
+  '#unwrapOr': d.fn(|||
+    Unwraps the result, returning the contained value if it's `ok`, or returning a default value if it's `err`.
+  |||, [
+    d.arg('or', d.T.any),
+  ]),
+  unwrapOr: function(or)
+    if this._type == 'ok' then
+      this._result
+    else
+      or
+  ,
+  '#match': d.fn(|||
+    Matches on the result, calling `ok(value)` if it's `ok`, or `err(error)` if it's `err`.
+
+    A new result can be returned from the match functions to chain operations, or any value can be returned to break the chain.
+    Both functions can be omitted.
+    `ok` defaults to returning a ok result with the value, and `err` defaults to returning an err result with the error message.
+  |||, [
+    d.arg('ok', d.T.func),
+    d.arg('err', d.T.func),
+  ]),
+  match: function(
+    ok=function(res) result {
+      _result: res,
+      _type: 'ok',
+    }, err=function(msg) result {
+      _error: msg,
+      _type: 'error',
+    }
+        )
+    if this._type == 'ok' then
+      ok(this._result)
+    else
+      err(this._error),
+};
+
+local ok(any) = result {
+  _result: any,
+  _type: 'ok',
+};
+
+local err(msg) = result {
+  _error: msg,
+  _type: 'error',
+};
+
+{
+  '#': d.pkg(
+    name='errors',
+    url='errors.libsonnet',
+    help=|||
+      `errors` Implements error handling utilities.
+
+      Jsonnet errors immediately terminate the program, which makes it difficult to handle errors gracefully.
+      This library provides a `result` type that can be used to represent either a successful result or an error,
+      allowing you to handle errors without crashing the entire program.
+
+      It is inspired by Rust's `Result` type.
+
+      ```jsonnet
+      local errors = import 'errors.libsonnet';
+
+      local divide = function(a, b)
+        if b == 0 then
+          errors.err('division by zero')
+        else
+          errors.ok(a / b)
+        ;
+
+      local result1 = divide(10, 2); // ok(5)
+      local result2 = divide(10, 0); // err('division by zero')
+
+      local value1 = result1.unwrapOr(0); // 5
+      local value2 = result2.unwrapOr(0); // 0
+
+      local value1 = result1.unwrap(); // 5
+      local value2 = result2.unwrap(); // throws an error with message 'division by zero'
+
+      local message1 = result1.match(
+        ok=function(value) 'Result is ' + std.toString(value),
+        err=function(msg) 'Error: ' + msg,
+      ); // 'Result is 5'
+      ```
+    |||,
+  ),
+  '#ok': d.fn(|||
+    Ok creates a successful result containing the given value.
+  |||, [
+    d.arg('any', d.T.any),
+  ]),
+  ok: ok,
+  '#err': d.fn(|||
+    Err creates an error result containing the given error message.
+  |||, [
+    d.arg('msg', d.T.string),
+  ]),
+  err: err,
+  '#result': d.obj(
+    'A result can be either a successful value or an error message. It provides methods to handle both cases. Should be created using `ok` or `err` functions.',
+  ),
+  result: result,
+}

--- a/contrib/lib/errors_test.jsonnet
+++ b/contrib/lib/errors_test.jsonnet
@@ -1,0 +1,43 @@
+local errors = import 'errors.libsonnet';
+local JSONNETUNIT = import 'github.com/bastjan/jsonnunit/lib/jsonnunit.libsonnet';
+
+JSONNETUNIT.describe(
+  'ok',
+  JSONNETUNIT.it(
+    'should create an ok result',
+    JSONNETUNIT.expect(errors.ok(42).unwrap()).to.equal(42)
+  )
+).describe(
+  'err',
+  JSONNETUNIT.it(
+    'should create an err result',
+    JSONNETUNIT.expect(errors.err('something went wrong').match(err=function(msg) msg)).to.equal('something went wrong')
+  )
+).describe(
+  'unwrap',
+  JSONNETUNIT.it(
+    'should unwrap an ok result',
+    JSONNETUNIT.expect(errors.ok('success').unwrap()).to.equal('success')
+  ).it(
+    "SKIPPED - can't currently be tested as jsonnet aborts immediately on error - should throw an error when unwrapping an err result",
+    JSONNETUNIT.expect(true).to.be['true']
+  )
+).describe(
+  'unwrapOr',
+  JSONNETUNIT.it(
+    'should unwrap an ok result',
+    JSONNETUNIT.expect(errors.ok('success').unwrapOr('default')).to.equal('success')
+  ).it(
+    'should return default value when unwrapping an err result',
+    JSONNETUNIT.expect(errors.err('failure').unwrapOr('default')).to.equal('default')
+  )
+).describe(
+  'match',
+  JSONNETUNIT.it(
+    'should match on an ok result',
+    JSONNETUNIT.expect(errors.ok(42).match(ok=function(value) value * 2)).to.equal(84)
+  ).it(
+    'should match on an err result',
+    JSONNETUNIT.expect(errors.err('error').match(err=function(msg) 'handled: ' + msg)).to.equal('handled: error')
+  )
+)

--- a/contrib/lib/jsonnetfile.json
+++ b/contrib/lib/jsonnetfile.json
@@ -1,0 +1,24 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/bastjan/jsonnunit.git",
+          "subdir": ""
+        }
+      },
+      "version": "main"
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "master"
+    }
+  ],
+  "legacyImports": false
+}

--- a/contrib/lib/jsonnetfile.lock.json
+++ b/contrib/lib/jsonnetfile.lock.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "dependencies": [
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/bastjan/jsonnunit.git",
+          "subdir": ""
+        }
+      },
+      "version": "368aab7472671f941517fae15b62d2545090c1dc",
+      "sum": "+drTWVzA1TuXMp4HWNDjo1ESp9EWzl2SzhN9vXbqeG8="
+    },
+    {
+      "source": {
+        "git": {
+          "remote": "https://github.com/jsonnet-libs/docsonnet.git",
+          "subdir": ""
+        }
+      },
+      "version": "bf6f08ae02a51c48bdcec4629b1c1a5a62c6f803",
+      "sum": "EnrolNeh0xbgNuD/XitdLiym4FzeYpL2JzMDzXuR7Co="
+    }
+  ],
+  "legacyImports": false
+}

--- a/contrib/lib/test.sh
+++ b/contrib/lib/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -euo pipefail
+
+jb() {
+  go tool github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb "$@"
+}
+
+jsonnet() {
+  go tool github.com/google/go-jsonnet/cmd/jsonnet "$@"
+}
+
+jb install
+
+for test in *_test.jsonnet; do
+  echo "Running ./$test"
+  jsonnet -S -J vendor -e '(import "github.com/bastjan/jsonnunit/lib/runner.libsonnet").run(std.extVar("t"))' --ext-code-file t="$test"
+done
+
+echo "Manually testing errors.libsonnet#result.unwrap"
+
+if out=$(jsonnet -e '(import "errors.libsonnet").err("some error").unwrap()' 2>&1); then
+  echo "Expected error, got success"
+  exit 1
+else
+  grep -q "RUNTIME ERROR: some error" <<< "$out" || {
+    echo "Expected error message to contain 'RUNTIME ERROR: some error', got: $out"
+    exit 1
+  }
+fi
+
+echo "PASSED"

--- a/docs/contrib/lib/accessors.libsonnet/README.md
+++ b/docs/contrib/lib/accessors.libsonnet/README.md
@@ -1,0 +1,65 @@
+---
+permalink: /
+---
+
+# accessors
+
+```jsonnet
+local accessors = import "accessors.libsonnet"
+```
+
+`accessors` implements accessors for Kubernetes manifests/ objects.
+
+## Index
+
+* [`fn getAnnotation(obj, annotation)`](#fn-getannotation)
+* [`fn getLabel(obj, label)`](#fn-getlabel)
+* [`fn getName(obj)`](#fn-getname)
+* [`fn getNamespace(obj)`](#fn-getnamespace)
+* [`fn inDelete(obj)`](#fn-indelete)
+
+## Fields
+
+### fn getAnnotation
+
+```ts
+getAnnotation(obj, annotation)
+```
+
+Gets the value of an annotation from an object. Null is returned if the annotation is not set.
+
+
+### fn getLabel
+
+```ts
+getLabel(obj, label)
+```
+
+Gets the value of a label from an object. Null is returned if the label is not set.
+
+
+### fn getName
+
+```ts
+getName(obj)
+```
+
+Gets the name of an object. Empty string is returned if the name is not set.
+
+
+### fn getNamespace
+
+```ts
+getNamespace(obj)
+```
+
+Gets the namespace of an object. Empty string is returned if the namespace is not set.
+
+
+### fn inDelete
+
+```ts
+inDelete(obj)
+```
+
+Checks if an object is in the process of being deleted.

--- a/docs/contrib/lib/errors.libsonnet/README.md
+++ b/docs/contrib/lib/errors.libsonnet/README.md
@@ -1,0 +1,106 @@
+---
+permalink: /
+---
+
+# errors
+
+```jsonnet
+local errors = import "errors.libsonnet"
+```
+
+`errors` Implements error handling utilities.
+
+Jsonnet errors immediately terminate the program, which makes it difficult to handle errors gracefully.
+This library provides a `result` type that can be used to represent either a successful result or an error,
+allowing you to handle errors without crashing the entire program.
+
+It is inspired by Rust's `Result` type.
+
+```jsonnet
+local errors = import 'errors.libsonnet';
+
+local divide = function(a, b)
+  if b == 0 then
+    errors.err('division by zero')
+  else
+    errors.ok(a / b)
+  ;
+
+local result1 = divide(10, 2); // ok(5)
+local result2 = divide(10, 0); // err('division by zero')
+
+local value1 = result1.unwrapOr(0); // 5
+local value2 = result2.unwrapOr(0); // 0
+
+local value1 = result1.unwrap(); // 5
+local value2 = result2.unwrap(); // throws an error with message 'division by zero'
+
+local message1 = result1.match(
+  ok=function(value) 'Result is ' + std.toString(value),
+  err=function(msg) 'Error: ' + msg,
+); // 'Result is 5'
+```
+
+
+## Index
+
+* [`fn err(msg)`](#fn-err)
+* [`fn ok(any)`](#fn-ok)
+* [`obj result`](#obj-result)
+  * [`fn match(ok, err)`](#fn-resultmatch)
+  * [`fn unwrap()`](#fn-resultunwrap)
+  * [`fn unwrapOr(or)`](#fn-resultunwrapor)
+
+## Fields
+
+### fn err
+
+```ts
+err(msg)
+```
+
+Err creates an error result containing the given error message.
+
+
+### fn ok
+
+```ts
+ok(any)
+```
+
+Ok creates a successful result containing the given value.
+
+
+## obj result
+
+A result can be either a successful value or an error message. It provides methods to handle both cases. Should be created using `ok` or `err` functions.
+
+### fn result.match
+
+```ts
+match(ok, err)
+```
+
+Matches on the result, calling `ok(value)` if it's `ok`, or `err(error)` if it's `err`.
+
+A new result can be returned from the match functions to chain operations, or any value can be returned to break the chain.
+Both functions can be omitted.
+`ok` defaults to returning a ok result with the value, and `err` defaults to returning an err result with the error message.
+
+
+### fn result.unwrap
+
+```ts
+unwrap()
+```
+
+Unwraps the result, returning the contained value if it's `ok`, or throwing an error if it's `err`.
+
+
+### fn result.unwrapOr
+
+```ts
+unwrapOr(or)
+```
+
+Unwraps the result, returning the contained value if it's `ok`, or returning a default value if it's `err`.

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,8 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
@@ -42,6 +44,7 @@ require (
 	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/elastic/crd-ref-docs v0.3.0 // indirect
+	github.com/elliotchance/orderedmap/v2 v2.2.0 // indirect
 	github.com/emicklei/go-restful/v3 v3.13.0 // indirect
 	github.com/evanphx/json-patch v5.9.0+incompatible // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
@@ -80,6 +83,7 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/jsonnet-bundler/jsonnet-bundler v0.6.0 // indirect
 	github.com/jsonnet-libs/docsonnet v0.0.7-0.20260326145441-bf6f08ae02a5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/markbates/pkger v0.17.1 // indirect
@@ -131,6 +135,7 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
+	gopkg.in/alecthomas/kingpin.v2 v2.2.6 // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
@@ -155,7 +160,9 @@ require (
 
 tool (
 	github.com/elastic/crd-ref-docs
+	github.com/google/go-jsonnet/cmd/jsonnet
 	github.com/google/go-jsonnet/cmd/jsonnetfmt
+	github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 	github.com/jsonnet-libs/docsonnet
 	golang.org/x/tools/cmd/stringer
 	sigs.k8s.io/controller-runtime/tools/setup-envtest

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,10 @@ github.com/Masterminds/semver/v3 v3.4.0 h1:Zog+i5UMtVoCU8oKka5P7i9q9HgrJeGzI9SA1
 github.com/Masterminds/semver/v3 v3.4.0/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lprf4nC11bSS5beM=
 github.com/Masterminds/sprig/v3 v3.3.0 h1:mQh0Yrg1XPo6vjYXgtf5OtijNAKJRNcTdOOGZe3tPhs=
 github.com/Masterminds/sprig/v3 v3.3.0/go.mod h1:Zy1iXRYNqNLUolqCpL4uhk6SHUMAOSCzdgBfDb35Lz0=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
+github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b/go.mod h1:fvzegU4vN3H1qMT+8wDmzjAcDONcgo2/SZ/TyfdUOFs=
 github.com/antlr4-go/antlr/v4 v4.13.1 h1:SqQKkuVZ+zWkMMNkjy5FZe5mr5WURWnlpmOuzYWrPrQ=
 github.com/antlr4-go/antlr/v4 v4.13.1/go.mod h1:GKmUxMtwp6ZgGwZSva4eWPC5mS6vUAmOABFgjdkM7Nw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -33,6 +37,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/elastic/crd-ref-docs v0.3.0 h1:9bGSUkBR56Z7TuDGQAu3KGbBkagwwZ6RkZmS+qvDuDM=
 github.com/elastic/crd-ref-docs v0.3.0/go.mod h1:8td3UC8CaO5M+G115O3FRKLmplmX+p0EqLMLGM6uNdk=
+github.com/elliotchance/orderedmap/v2 v2.2.0 h1:7/2iwO98kYT4XkOjA9mBEIwvi4KpGB4cyHeOFOnj4Vk=
+github.com/elliotchance/orderedmap/v2 v2.2.0/go.mod h1:85lZyVbpGaGvHvnKa7Qhx7zncAdBIBq6u56Hb1PRU5Q=
 github.com/emicklei/go-restful/v3 v3.13.0 h1:C4Bl2xDndpU6nJ4bc1jXd+uTmYPVUwkD6bFY/oTyCes=
 github.com/emicklei/go-restful/v3 v3.13.0/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/evanphx/json-patch v5.9.0+incompatible h1:fBXyNpNMuTTDdquAq/uisOr2lShz4oaXpDTX2bLe7ls=
@@ -140,6 +146,8 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jsonnet-bundler/jsonnet-bundler v0.6.0 h1:DBnynmjyWBVQ9gUBmTh49x3Dw5/u4CvGO3k2k1CsYNo=
+github.com/jsonnet-bundler/jsonnet-bundler v0.6.0/go.mod h1:5esRxD59TyScj6qxT3o7GH0sryBKvVmx2zaEYDXtQkg=
 github.com/jsonnet-libs/docsonnet v0.0.7-0.20260326145441-bf6f08ae02a5 h1:4PPxNkF7sDVOgSxQW+r8tR+fZY8Afi+hPMzk0ca24J8=
 github.com/jsonnet-libs/docsonnet v0.0.7-0.20260326145441-bf6f08ae02a5/go.mod h1:A7GAoddNfvUyc22xyixJnc78PDivRv7NWT55iXAZiME=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
@@ -227,6 +235,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
@@ -302,6 +312,8 @@ google.golang.org/grpc v1.79.3 h1:sybAEdRIEtvcD68Gx7dmnwjZKlyfuc61Dyo9pGXXkKE=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=
 google.golang.org/protobuf v1.36.11 h1:fV6ZwhNocDyBLK0dj+fg8ektcVegBBuEolpbTQyBNVE=
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
* `accessors.libsonnet`: Commonly used accessors to object metadata.
* `errors.libsonnet`: Graceful error handling inspired by the rust result type.

The libraries are tested using my fork of `jsonnetunit` (https://github.com/bastjan/jsonnunit) and documented using `docsonnet`.

The libraries are added to the deployment config and can be added with `kustomize build config/contrib`.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
