### PR TITLE
Admission: Make the associated namespace object of the admission request accessible in the template

### DIFF
--- a/admission/handler.go
+++ b/admission/handler.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-jsonnet/ast"
 	"github.com/prometheus/client_golang/prometheus"
 	"gomodules.xyz/jsonpatch/v2"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -43,6 +44,7 @@ func init() {
 
 //+kubebuilder:rbac:groups=espejote.io,resources=admissions,verbs=get;list;watch
 //+kubebuilder:rbac:groups=espejote.io,resources=jsonnetlibraries,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch
 
 type pathContextKey struct{}
 
@@ -138,6 +140,19 @@ func (h *handler) handle(ctx context.Context, admissionKey types.NamespacedName,
 		return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to marshal request: %w", err))
 	}
 	jvm.ExtCode("__internal_use_espejote_lib_admissionrequest", string(reqJson))
+	if req.Namespace != "" {
+		var ns corev1.Namespace
+		if err := h.Client.Get(ctx, types.NamespacedName{Name: req.Namespace}, &ns); err != nil {
+			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to get namespace: %w", err))
+		}
+		nsJson, err := json.Marshal(ns)
+		if err != nil {
+			return admission.Errored(http.StatusInternalServerError, fmt.Errorf("failed to marshal namespace: %w", err))
+		}
+		jvm.ExtCode("__internal_use_espejote_lib_namespace", string(nsJson))
+	} else {
+		jvm.ExtCode("__internal_use_espejote_lib_namespace", `null`)
+	}
 
 	ret, err := jvm.EvaluateAnonymousSnippet("admission", admTemplate)
 	if err != nil {

--- a/admission/handler_test.go
+++ b/admission/handler_test.go
@@ -82,14 +82,25 @@ func Test_Handler_ClusterAdmissionNotFound(t *testing.T) {
 func Test_Handler_Allowed(t *testing.T) {
 	t.Parallel()
 
-	c := buildFakeClient(t, &espejotev1alpha1.Admission{
+	const targetNamespace = "target-namespace"
+
+	c := buildFakeClient(t, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: targetNamespace,
+			Annotations: map[string]string{
+				"breadcrumb": "test",
+			},
+		},
+	}, &espejotev1alpha1.Admission{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test",
-			Namespace: "default",
+			Namespace: targetNamespace,
 		},
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Template: `
 			local esp = import 'espejote.libsonnet';
+
+			assert esp.ALPHA.admission.namespaceObject().metadata.annotations.breadcrumb == "test";
 
 			esp.ALPHA.admission.allowed("Nice job!")
 `,
@@ -100,8 +111,9 @@ func Test_Handler_Allowed(t *testing.T) {
 	require.NotNil(t, subject)
 
 	w := httptest.NewRecorder()
-	req := newAdmissionRequest(t, "test", "default", admissionv1.AdmissionRequest{
-		UID: "test",
+	req := newAdmissionRequest(t, "test", targetNamespace, admissionv1.AdmissionRequest{
+		UID:       "test",
+		Namespace: targetNamespace,
 	})
 	subject.ServeHTTP(w, req)
 	res := w.Result()
@@ -127,6 +139,8 @@ func Test_Handler_Allowed_ClusterScoped(t *testing.T) {
 		Spec: espejotev1alpha1.ClusterAdmissionSpec{
 			Template: `
 			local esp = import 'espejote.libsonnet';
+
+			assert esp.ALPHA.admission.namespaceObject() == null;
 
 			esp.ALPHA.admission.allowed("Nice job!")
 `,

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - serviceaccounts/token
   verbs:
   - create

--- a/controllers/lib/espejote.libsonnet
+++ b/controllers/lib/espejote.libsonnet
@@ -3,6 +3,7 @@ local d = import 'github.com/jsonnet-libs/docsonnet/doc-util/main.libsonnet';
 local context = std.extVar('__internal_use_espejote_lib_context');
 local trigger = std.extVar('__internal_use_espejote_lib_trigger');
 local admissionRequest = std.extVar('__internal_use_espejote_lib_admissionrequest');
+local admissionNamespaceObject = std.extVar('__internal_use_espejote_lib_namespace');
 
 local admission = {
   '#admissionRequest': d.fn(
@@ -121,6 +122,14 @@ local admission = {
     |||,
   ),
   admissionRequest: function() admissionRequest,
+
+  '#namespaceObject': d.fn(
+    |||
+      `namespaceObject` allows access to the namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.
+      Reference: https://pkg.go.dev/k8s.io/api/core/v1#Namespace
+    |||,
+  ),
+  namespaceObject: function() admissionNamespaceObject,
 
   '#allowed': d.fn(
     |||

--- a/docs/lib/README.md
+++ b/docs/lib/README.md
@@ -25,6 +25,7 @@ local espejote = import "espejote.libsonnet"
     * [`fn assertPatch(msg, obj='#admissionRequest().object')`](#fn-alphaadmissionassertpatch)
     * [`fn denied(msg='')`](#fn-alphaadmissiondenied)
     * [`fn jsonPatchOp(op, path, value)`](#fn-alphaadmissionjsonpatchop)
+    * [`fn namespaceObject()`](#fn-alphaadmissionnamespaceobject)
     * [`fn patched(msg, patches)`](#fn-alphaadmissionpatched)
 
 ## Fields
@@ -355,6 +356,16 @@ jsonPatchOp(op, path, value)
 The operation is one of: add, remove, replace, move, copy, test.
 The path is a JSON pointer to the location in the object to apply the operation.
 The value is the value to set for add and replace operations.
+
+
+### fn ALPHA.admission.namespaceObject
+
+```ts
+namespaceObject()
+```
+
+`namespaceObject` allows access to the namespace object that the incoming object belongs to. The value is null for cluster-scoped resources.
+Reference: https://pkg.go.dev/k8s.io/api/core/v1#Namespace
 
 
 ### fn ALPHA.admission.patched

--- a/test/e2e/admission_e2e_test.go
+++ b/test/e2e/admission_e2e_test.go
@@ -45,6 +45,7 @@ metadata:
 		require.NoError(t, json.Unmarshal(out.Bytes(), &createdCM))
 		require.NotEmpty(t, createdCM.ObjectMeta.Annotations)
 		require.NotEmpty(t, createdCM.ObjectMeta.Annotations["creator"])
+		require.Equal(t, "e2e-test", createdCM.ObjectMeta.Annotations["environment"])
 	}, 1*time.Minute, 100*time.Microsecond, "Waiting for webhook to become ready and installed")
 
 	suite.T().Log("Creating subject cm...")

--- a/test/e2e/testdata/admission/basic.yaml
+++ b/test/e2e/testdata/admission/basic.yaml
@@ -5,7 +5,7 @@ metadata:
   name: mutating-admission
   annotations:
     description: |
-      Adds the annotation `creator` for ConfigMap create requests.
+      Adds the annotation `creator` for ConfigMap create requests and copies the `environment` annotation from the namespace to the ConfigMap.
 spec:
   mutating: true
   webhookConfiguration:
@@ -19,15 +19,17 @@ spec:
     local admission = esp.ALPHA.admission;
 
     local user = admission.admissionRequest().userInfo.username;
+    local environment = admission.namespaceObject().metadata.annotations.environment;
     local obj = admission.admissionRequest().object;
 
     if std.get(obj.metadata, 'annotations') == null then
       admission.patched('added user annotation', admission.assertPatch([
-        admission.jsonPatchOp('add', '/metadata/annotations', { 'creator': user }),
+        admission.jsonPatchOp('add', '/metadata/annotations', { 'creator': user, 'environment': environment }),
       ]))
     else
       admission.patched('added user annotation', admission.assertPatch([
         admission.jsonPatchOp('add', '/metadata/annotations/creator', user),
+        admission.jsonPatchOp('add', '/metadata/annotations/environment', environment),
       ]))
 ---
 apiVersion: espejote.io/v1alpha1

--- a/test/e2e/utils.go
+++ b/test/e2e/utils.go
@@ -226,6 +226,8 @@ apiVersion: v1
 kind: Namespace
 metadata:
   generateName: espejote-e2e-
+  annotations:
+    environment: e2e-test
 `)
 	return strings.TrimSpace(requireRun(t, cmd))
 }


### PR DESCRIPTION
This brings espejote Admissions closer to feature-parity with `MutatingAdmissionPolicies` that support access in their CEL templates.

See https://kubernetes.io/docs/reference/kubernetes-api/admissionregistration/mutating-admission-policy-v1/#ApplyConfiguration

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
- [x] Update tests.
