### PR TITLE
fix(website): point repo_url at website/ so edit links resolve

### DIFF
--- a/website/config/_default/params.yaml
+++ b/website/config/_default/params.yaml
@@ -12,7 +12,11 @@ custom_css: []
 images: ["/img/social-share.png"]
 
 github:
-  repo_url: "https://github.com/vshn/espejote/blob/main"
+  # Must point at the directory that contains content/, not at the repository
+  # root: the theme builds the edit link as `<repo_url>/content/<lang>/<page>`.
+  # The Hugo site lives under website/, so without that segment every "Edit
+  # this page on GitHub" link 404s.
+  repo_url: "https://github.com/vshn/espejote/blob/main/website"
   show_edit_link: true
 
 social_links:


### PR DESCRIPTION
Closes #236.

## What

`website/config/_default/params.yaml`: `repo_url` gains the `/website` segment.

Every "Edit this page on GitHub" link on espejote.io 404s today. Live from the homepage:

```html
href="https://github.com/vshn/espejote/blob/main/content/en/_index.md"
```

There is no `content/` at the repository root.

## Why

`layouts/partials/footer/github.html` in the theme:

```go-html-template
{{ $editURL := printf "%s/content/%s/%s" $.Site.Params.github.repo_url $langPrefix $pageRelPath }}
```

`repo_url` has to name the directory that *contains* `content/`. The theme's `exampleSite` sets it to a repository root, which is right for a repo whose Hugo site is the root. This one keeps the site under `website/`, so the segment is missing. A comment on the value now says what it has to point at, since the mistake is invisible in the config and only shows on the rendered page.

## Scope

All three pages, not just the homepage: `_index.md`, `about.md`, `roadmap.md`. Lychee reported only the homepage because that is the page it crawled.

## Verification

Before, all 404:

- `https://github.com/vshn/espejote/blob/main/content/en/_index.md`

After, all 200:

- `https://github.com/vshn/espejote/blob/main/website/content/en/_index.md`
- `https://github.com/vshn/espejote/blob/main/website/content/en/about.md`
- `https://github.com/vshn/espejote/blob/main/website/content/en/roadmap.md`

Checked by hand on 2026-09-02. I did not build the site locally (no Hugo on this machine, and the theme is a submodule), so the rendered anchor is worth a look on the preview or after deploy rather than taking the config change on trust.

## How it surfaced

The daily Lychee run over the external VSHN properties, added in vshn/landingpager#548. First real run 2026-09-02.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GYwDQEeeoKaXBc6kSWtvxa
