### PR TITLE
Go 1.27

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -29,8 +29,6 @@ jobs:
 
       - name: Run govulncheck and save to file
         run: go run golang.org/x/vuln/cmd/govulncheck@latest -format sarif ./... > govulncheck.sarif
-        env:
-          GOEXPERIMENT: jsonv2
 
       - name: Upload SARIF File
         uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,7 +7,6 @@ before:
 builds:
 - env:
   - CGO_ENABLED=0 # this is needed otherwise the Docker image build is faulty
-  - GOEXPERIMENT=jsonv2
   goarch:
   - amd64
   - arm64

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,6 @@ MAKEFLAGS += --no-builtin-variables
 .SECONDARY:
 .DEFAULT_GOAL := help
 
-export GOEXPERIMENT = jsonv2
-
 JSONNET_FILES   ?= $(shell find . -type f -not -path './vendor/*' -not -path './contrib/lib/vendor/*' \( -name '*.*jsonnet' -or -name '*.libsonnet' \))
 
 include Makefile.vars.mk

--- a/admission/handler_test.go
+++ b/admission/handler_test.go
@@ -15,10 +15,8 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -85,17 +83,13 @@ func Test_Handler_Allowed(t *testing.T) {
 	const targetNamespace = "target-namespace"
 
 	c := buildFakeClient(t, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: targetNamespace,
-			Annotations: map[string]string{
-				"breadcrumb": "test",
-			},
+		Name: targetNamespace,
+		Annotations: map[string]string{
+			"breadcrumb": "test",
 		},
 	}, &espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: targetNamespace,
-		},
+		Name:      "test",
+		Namespace: targetNamespace,
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Template: `
 			local esp = import 'espejote.libsonnet';
@@ -133,9 +127,7 @@ func Test_Handler_Allowed_ClusterScoped(t *testing.T) {
 	t.Parallel()
 
 	c := buildFakeClient(t, &espejotev1alpha1.ClusterAdmission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test",
-		},
+		Name: "test",
 		Spec: espejotev1alpha1.ClusterAdmissionSpec{
 			Template: `
 			local esp = import 'espejote.libsonnet';
@@ -172,10 +164,8 @@ func Test_Handler_Denied(t *testing.T) {
 	t.Parallel()
 
 	c := buildFakeClient(t, &espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
+		Name:      "test",
+		Namespace: "default",
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Template: `
 			local esp = import 'espejote.libsonnet';
@@ -210,10 +200,8 @@ func Test_Handler_Patched(t *testing.T) {
 	t.Parallel()
 
 	c := buildFakeClient(t, &espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
+		Name:      "test",
+		Namespace: "default",
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Template: `
   local esp = import 'espejote.libsonnet';
@@ -238,18 +226,14 @@ func Test_Handler_Patched(t *testing.T) {
 			Username: "testuser",
 		},
 		Object: objectToRaw(t, &appsv1.Deployment{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-				Annotations: map[string]string{
-					"test": "test",
-				},
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "test",
+			Annotations: map[string]string{
+				"test": "test",
 			},
 			Spec: appsv1.DeploymentSpec{
-				Replicas: ptr.To(int32(3)),
+				Replicas: new(int32(3)),
 			},
 		}),
 	})
@@ -272,10 +256,8 @@ func Test_Handler_Patched_InvalidPatch(t *testing.T) {
 	t.Parallel()
 
 	c := buildFakeClient(t, &espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
-			Namespace: "default",
-		},
+		Name:      "test",
+		Namespace: "default",
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Template: `
   local esp = import 'espejote.libsonnet';
@@ -300,13 +282,9 @@ func Test_Handler_Patched_InvalidPatch(t *testing.T) {
 			Username: "testuser",
 		},
 		Object: objectToRaw(t, &corev1.Namespace{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "Namespace",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-			},
+			APIVersion: "v1",
+			Kind:       "Namespace",
+			Name:       "test",
 		}),
 	})
 	subject.ServeHTTP(w, req)

--- a/cmd/collect_input_test.go
+++ b/cmd/collect_input_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/vshn/espejote/testutil"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
@@ -40,11 +39,9 @@ func Test_runCollectInput(t *testing.T) {
 
 			for i := range 10 {
 				cm := &corev1.ConfigMap{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      fmt.Sprintf("test-%d", i),
-						Namespace: testns,
-						Labels:    map[string]string{},
-					},
+					Name:      fmt.Sprintf("test-%d", i),
+					Namespace: testns,
+					Labels:    map[string]string{},
 				}
 				if i%2 != 0 {
 					cm.Labels["odd"] = "true"
@@ -52,10 +49,8 @@ func Test_runCollectInput(t *testing.T) {
 				require.NoError(t, cli.Create(t.Context(), cm))
 			}
 			lib := &espejotev1alpha1.JsonnetLibrary{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "jsonnetlibrary-sample",
-					Namespace: testns,
-				},
+				Name:      "jsonnetlibrary-sample",
+				Namespace: testns,
 				Spec: espejotev1alpha1.JsonnetLibrarySpec{
 					Data: map[string]string{
 						"sample.libsonnet": `import "relrel.libsonnet"`,

--- a/cmd/render_test.go
+++ b/cmd/render_test.go
@@ -12,7 +12,6 @@ import (
 	espejotev1alpha1 "github.com/vshn/espejote/api/v1alpha1"
 	"github.com/vshn/espejote/testutil"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -34,11 +33,9 @@ func Test_runRender_Cluster(t *testing.T) {
 
 	for i := range 10 {
 		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("test-%d", i),
-				Namespace: testns,
-				Labels:    map[string]string{},
-			},
+			Name:      fmt.Sprintf("test-%d", i),
+			Namespace: testns,
+			Labels:    map[string]string{},
 		}
 		if i%2 != 0 {
 			cm.Labels["odd"] = "true"
@@ -46,10 +43,8 @@ func Test_runRender_Cluster(t *testing.T) {
 		require.NoError(t, cli.Create(t.Context(), cm))
 	}
 	lib := &espejotev1alpha1.JsonnetLibrary{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "jsonnetlibrary-sample",
-			Namespace: testns,
-		},
+		Name:      "jsonnetlibrary-sample",
+		Namespace: testns,
 		Spec: espejotev1alpha1.JsonnetLibrarySpec{
 			Data: map[string]string{
 				"sample.libsonnet": `import "relrel.libsonnet"`,

--- a/controllers/admission_controller.go
+++ b/controllers/admission_controller.go
@@ -90,8 +90,8 @@ func (r *AdmissionReconciler) Reconcile(ctx context.Context, _ admissionRequest)
 				Service: &admissionregistrationv1.ServiceReference{
 					Name:      r.WebhookServiceName,
 					Namespace: r.ControllerNamespace,
-					Path:      ptr.To(path.Join("/dynamic", admission.Namespace, admission.Name)),
-					Port:      ptr.To(r.WebhookPort),
+					Path:      new(path.Join("/dynamic", admission.Namespace, admission.Name)),
+					Port:      new(r.WebhookPort),
 				},
 			},
 			NamespaceSelector: &metav1.LabelSelector{
@@ -118,8 +118,8 @@ func (r *AdmissionReconciler) Reconcile(ctx context.Context, _ admissionRequest)
 				Service: &admissionregistrationv1.ServiceReference{
 					Name:      r.WebhookServiceName,
 					Namespace: r.ControllerNamespace,
-					Path:      ptr.To(path.Join("/dynamic-cluster", admission.Name)),
-					Port:      ptr.To(r.WebhookPort),
+					Path:      new(path.Join("/dynamic-cluster", admission.Name)),
+					Port:      new(r.WebhookPort),
 				},
 			},
 
@@ -151,8 +151,8 @@ func (r *AdmissionReconciler) Reconcile(ctx context.Context, _ admissionRequest)
 				Service: &admissionregistrationv1.ServiceReference{
 					Name:      r.WebhookServiceName,
 					Namespace: r.ControllerNamespace,
-					Path:      ptr.To(path.Join("/dynamic", admission.Namespace, admission.Name)),
-					Port:      ptr.To(r.WebhookPort),
+					Path:      new(path.Join("/dynamic", admission.Namespace, admission.Name)),
+					Port:      new(r.WebhookPort),
 				},
 			},
 			NamespaceSelector: &metav1.LabelSelector{
@@ -178,8 +178,8 @@ func (r *AdmissionReconciler) Reconcile(ctx context.Context, _ admissionRequest)
 				Service: &admissionregistrationv1.ServiceReference{
 					Name:      r.WebhookServiceName,
 					Namespace: r.ControllerNamespace,
-					Path:      ptr.To(path.Join("/dynamic-cluster", admission.Name)),
-					Port:      ptr.To(r.WebhookPort),
+					Path:      new(path.Join("/dynamic-cluster", admission.Name)),
+					Port:      new(r.WebhookPort),
 				},
 			},
 

--- a/controllers/admission_controller_test.go
+++ b/controllers/admission_controller_test.go
@@ -56,10 +56,8 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	testns := testutil.TmpNamespace(t, c)
 
 	val := espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "val",
-			Namespace: testns,
-		},
+		Name:      "val",
+		Namespace: testns,
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Mutating: false,
 			WebhookConfiguration: espejotev1alpha1.WebhookConfiguration{
@@ -68,12 +66,10 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 						Operations: []admissionregistrationv1.OperationType{
 							admissionregistrationv1.Create,
 						},
-						Rule: admissionregistrationv1.Rule{
-							Scope:       ptr.To(admissionregistrationv1.AllScopes),
-							APIGroups:   []string{"*"},
-							APIVersions: []string{"*"},
-							Resources:   []string{"*"},
-						},
+						Scope:       ptr.To(admissionregistrationv1.AllScopes),
+						APIGroups:   []string{"*"},
+						APIVersions: []string{"*"},
+						Resources:   []string{"*"},
 					},
 				},
 			},
@@ -81,10 +77,8 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	}
 	require.NoError(t, c.Create(ctx, &val))
 	val2 := espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "zz-val",
-			Namespace: testns,
-		},
+		Name:      "zz-val",
+		Namespace: testns,
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Mutating:             false,
 			WebhookConfiguration: *val.Spec.WebhookConfiguration.DeepCopy(),
@@ -92,10 +86,8 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	}
 	require.NoError(t, c.Create(ctx, &val2))
 	mut := espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mut",
-			Namespace: testns,
-		},
+		Name:      "mut",
+		Namespace: testns,
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Mutating:             true,
 			WebhookConfiguration: *val.Spec.WebhookConfiguration.DeepCopy(),
@@ -104,15 +96,11 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	require.NoError(t, c.Create(ctx, &mut))
 
 	require.NoError(t, c.Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "zz-" + testns,
-		},
+		Name: "zz-" + testns,
 	}))
 	mut2 := espejotev1alpha1.Admission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "mut",
-			Namespace: "zz-" + testns,
-		},
+		Name:      "mut",
+		Namespace: "zz-" + testns,
 		Spec: espejotev1alpha1.AdmissionSpec{
 			Mutating:             true,
 			WebhookConfiguration: *val.Spec.WebhookConfiguration.DeepCopy(),
@@ -121,9 +109,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	require.NoError(t, c.Create(ctx, &mut2))
 
 	clusterVal := espejotev1alpha1.ClusterAdmission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "val-" + testns,
-		},
+		Name: "val-" + testns,
 		Spec: espejotev1alpha1.ClusterAdmissionSpec{
 			Mutating: false,
 			WebhookConfiguration: espejotev1alpha1.WebhookConfigurationWithNamespaceSelector{
@@ -143,9 +129,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	require.NoError(t, c.Create(ctx, &clusterVal))
 
 	clusterVal2 := espejotev1alpha1.ClusterAdmission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "zz-val-" + testns,
-		},
+		Name: "zz-val-" + testns,
 		Spec: espejotev1alpha1.ClusterAdmissionSpec{
 			Mutating:             false,
 			WebhookConfiguration: *clusterVal.Spec.WebhookConfiguration.DeepCopy(),
@@ -154,9 +138,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	require.NoError(t, c.Create(ctx, &clusterVal2))
 
 	clusterMut := espejotev1alpha1.ClusterAdmission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mut-" + testns,
-		},
+		Name: "mut-" + testns,
 		Spec: espejotev1alpha1.ClusterAdmissionSpec{
 			Mutating:             true,
 			WebhookConfiguration: *clusterVal.Spec.WebhookConfiguration.DeepCopy(),
@@ -165,9 +147,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	require.NoError(t, c.Create(ctx, &clusterMut))
 
 	clusterMut2 := espejotev1alpha1.ClusterAdmission{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "zz-mut-" + testns,
-		},
+		Name: "zz-mut-" + testns,
 		Spec: espejotev1alpha1.ClusterAdmissionSpec{
 			Mutating:             true,
 			WebhookConfiguration: *clusterVal.Spec.WebhookConfiguration.DeepCopy(),
@@ -190,7 +170,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 		c := mutwebhook.Webhooks[0]
 		assert.Equal(t, "system", c.ClientConfig.Service.Namespace)
 		assert.Equal(t, strings.Join([]string{"/dynamic", mut.Namespace, mut.Name}, "/"), *c.ClientConfig.Service.Path)
-		assert.Equal(t, ptr.To(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
+		assert.Equal(t, new(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
 		assert.Equal(t, map[string]string{"kubernetes.io/metadata.name": testns}, c.NamespaceSelector.MatchLabels)
 		if assert.Len(t, c.Rules, 1) {
 			assert.Equal(t, ptr.To(admissionregistrationv1.NamespacedScope), c.Rules[0].Scope, "scope should be Namespaced for namespaced admission")
@@ -200,7 +180,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 		c := mutwebhook.Webhooks[2]
 		assert.Equal(t, "system", c.ClientConfig.Service.Namespace)
 		assert.Equal(t, strings.Join([]string{"/dynamic-cluster", clusterMut.Name}, "/"), *c.ClientConfig.Service.Path)
-		assert.Equal(t, ptr.To(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
+		assert.Equal(t, new(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
 		assert.Equal(t, &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
@@ -230,7 +210,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 		c := valwebhook.Webhooks[0]
 		assert.Equal(t, "system", c.ClientConfig.Service.Namespace)
 		assert.Equal(t, strings.Join([]string{"/dynamic", val.Namespace, val.Name}, "/"), *c.ClientConfig.Service.Path)
-		assert.Equal(t, ptr.To(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
+		assert.Equal(t, new(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
 		assert.Equal(t, map[string]string{"kubernetes.io/metadata.name": testns}, c.NamespaceSelector.MatchLabels)
 		if assert.Len(t, c.Rules, 1) {
 			assert.Equal(t, ptr.To(admissionregistrationv1.NamespacedScope), c.Rules[0].Scope, "scope should be Namespaced for namespaced admission")
@@ -240,7 +220,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 		c := valwebhook.Webhooks[2]
 		assert.Equal(t, "system", c.ClientConfig.Service.Namespace)
 		assert.Equal(t, strings.Join([]string{"/dynamic-cluster", clusterVal.Name}, "/"), *c.ClientConfig.Service.Path)
-		assert.Equal(t, ptr.To(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
+		assert.Equal(t, new(int32(subject.WebhookPort)), c.ClientConfig.Service.Port)
 		assert.Equal(t, &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
@@ -267,9 +247,7 @@ func Test_AdmissionReconciler_Reconcile(t *testing.T) {
 	}, 5*time.Second, 10*time.Millisecond)
 
 	require.NoError(t, c.Delete(ctx, &admissionregistrationv1.ValidatingWebhookConfiguration{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: webhookName,
-		},
+		Name: webhookName,
 	}))
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {

--- a/controllers/applygroup/applygroup.go
+++ b/controllers/applygroup/applygroup.go
@@ -12,7 +12,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	espejotev1alpha1 "github.com/vshn/espejote/api/v1alpha1"
@@ -351,7 +350,7 @@ func deleteOptionsFromRenderedObject(obj *unstructured.Unstructured) (shouldDele
 	}
 	if ok {
 		hasPreconditions = true
-		preconditions.UID = ptr.To(types.UID(preconditionUID))
+		preconditions.UID = new(types.UID(preconditionUID))
 	}
 	preconditionResourceVersion, ok, err := unstructured.NestedString(obj.UnstructuredContent(), deletionKey, "preconditionResourceVersion")
 	if err != nil {

--- a/controllers/jsonnet_test.go
+++ b/controllers/jsonnet_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -19,10 +18,8 @@ func Test_ManifestImporter_Import_NoLocalNamespace(t *testing.T) {
 		WithScheme(scheme).
 		WithObjects(
 			&espejotev1alpha1.JsonnetLibrary{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "shared",
-					Namespace: "lib-ns",
-				},
+				Name:      "shared",
+				Namespace: "lib-ns",
 				Spec: espejotev1alpha1.JsonnetLibrarySpec{
 					Data: map[string]string{
 						"test.libsonnet": `{}`,

--- a/controllers/managedresource_controller.go
+++ b/controllers/managedresource_controller.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/events"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -298,8 +297,7 @@ func (r *ManagedResourceReconciler) recordReconcileErr(ctx context.Context, req 
 
 	errType := "ReconcileError"
 	transient := false
-	var espejoteErr EspejoteError
-	if errors.As(recErr, &espejoteErr) {
+	if espejoteErr, ok := errors.AsType[EspejoteError](recErr); ok {
 		errType = string(espejoteErr.Type)
 		transient = espejoteErr.Transient()
 	}
@@ -477,7 +475,7 @@ func (r *ManagedResourceReconciler) uncachedClientForManagedResource(ctx context
 func (r *ManagedResourceReconciler) jwtTokenForSA(ctx context.Context, namespace, name string) (string, error) {
 	treq, err := r.clientset.CoreV1().ServiceAccounts(namespace).CreateToken(ctx, name, &authv1.TokenRequest{
 		Spec: authv1.TokenRequestSpec{
-			ExpirationSeconds: ptr.To(int64(60 * 60 * 24 * 365)), // 1 year
+			ExpirationSeconds: new(int64(60 * 60 * 24 * 365)), // 1 year
 		},
 	}, metav1.CreateOptions{})
 	if err != nil {

--- a/controllers/managedresource_controller_manager.go
+++ b/controllers/managedresource_controller_manager.go
@@ -158,8 +158,7 @@ func (r *ManagedResourceControllerManager) Reconcile(ctx context.Context, req re
 func (r *ManagedResourceControllerManager) recordErr(ctx context.Context, err error, defaultErrType string, managedResource espejotev1alpha1.ManagedResource, req reconcile.Request) error {
 	errType := defaultErrType
 
-	var espejoteErr EspejoteError
-	if errors.As(err, &espejoteErr) {
+	if espejoteErr, ok := errors.AsType[EspejoteError](err); ok {
 		errType = string(espejoteErr.Type)
 	}
 
@@ -231,7 +230,7 @@ func (r *ManagedResourceControllerManager) ensureInstanceControllerFor(ctx conte
 			// to fix this nicely. This is quite annoying because you need to override
 			// the new workqueue function. Don't currently see the problem with just
 			// reusing the same metrics on recreate.
-			SkipNameValidation: ptr.To(true),
+			SkipNameValidation: new(true),
 			Reconciler:         reconciler,
 			Logger:             r.logger,
 			CacheSyncTimeout:   mr.Spec.CacheSyncTimeout.Duration,
@@ -495,7 +494,7 @@ func (r *ManagedResourceControllerManager) newCacheForResourceAndRESTClient(ctx 
 		DefaultLabelSelector:        lblSel,
 		// We don't want to deep copy the objects, as we don't modify them
 		// This is mostly to make metric collection more efficient
-		DefaultUnsafeDisableDeepCopy: ptr.To(true),
+		DefaultUnsafeDisableDeepCopy: new(true),
 
 		DefaultTransform: transformFunc,
 

--- a/controllers/managedresource_controller_test.go
+++ b/controllers/managedresource_controller_test.go
@@ -28,7 +28,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -108,16 +107,12 @@ func Test_ManagedResourceReconciler_Reconcile(t *testing.T) {
 		testns := testutil.TmpNamespace(t, c)
 
 		jsonnetLibNs := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: subject.JsonnetLibraryNamespace,
-			},
+			Name: subject.JsonnetLibraryNamespace,
 		}
 		require.NoError(t, c.Create(ctx, jsonnetLibNs))
 		jsonnetLib := &espejotev1alpha1.JsonnetLibrary{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: subject.JsonnetLibraryNamespace,
-			},
+			Name:      "test",
+			Namespace: subject.JsonnetLibraryNamespace,
 			Spec: espejotev1alpha1.JsonnetLibrarySpec{
 				Data: map[string]string{
 					"test.jsonnet":       `import "dotrel.jsonnet"`,
@@ -130,10 +125,8 @@ func Test_ManagedResourceReconciler_Reconcile(t *testing.T) {
 		}
 		require.NoError(t, c.Create(ctx, jsonnetLib))
 		jsonnetLib2 := &espejotev1alpha1.JsonnetLibrary{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test2",
-				Namespace: subject.JsonnetLibraryNamespace,
-			},
+			Name:      "test2",
+			Namespace: subject.JsonnetLibraryNamespace,
 			Spec: espejotev1alpha1.JsonnetLibrarySpec{
 				Data: map[string]string{
 					"test.jsonnet":   `import "relrel.jsonnet"`,
@@ -144,10 +137,8 @@ func Test_ManagedResourceReconciler_Reconcile(t *testing.T) {
 		}
 		require.NoError(t, c.Create(ctx, jsonnetLib2))
 		localJsonnetLib := &espejotev1alpha1.JsonnetLibrary{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.JsonnetLibrarySpec{
 				Data: map[string]string{
 					"test.jsonnet":   `import "relrel.jsonnet"`,
@@ -158,10 +149,8 @@ func Test_ManagedResourceReconciler_Reconcile(t *testing.T) {
 		}
 		require.NoError(t, c.Create(ctx, localJsonnetLib))
 		localJsonnetLib2 := &espejotev1alpha1.JsonnetLibrary{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test2",
-				Namespace: testns,
-			},
+			Name:      "test2",
+			Namespace: testns,
 			Spec: espejotev1alpha1.JsonnetLibrarySpec{
 				Data: map[string]string{
 					"test.jsonnet":   `import "relrel.jsonnet"`,
@@ -173,10 +162,8 @@ func Test_ManagedResourceReconciler_Reconcile(t *testing.T) {
 		require.NoError(t, c.Create(ctx, localJsonnetLib2))
 
 		res := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{
 					{
@@ -212,9 +199,7 @@ if esp.triggerName() == "ns" then [{
 		require.NoError(t, c.Create(ctx, res))
 
 		ns := &corev1.Namespace{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: testns + "-2",
-			},
+			Name: testns + "-2",
 		}
 		require.NoError(t, c.Create(ctx, ns))
 
@@ -232,10 +217,8 @@ if esp.triggerName() == "ns" then [{
 		testns := testutil.TmpNamespace(t, c)
 
 		otherCM := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "other",
-				Namespace: testns,
-			},
+			Name:      "other",
+			Namespace: testns,
 			Data: map[string]string{
 				"test": "test",
 			},
@@ -243,10 +226,8 @@ if esp.triggerName() == "ns" then [{
 		require.NoError(t, c.Create(ctx, otherCM))
 
 		res := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "configmap",
@@ -304,10 +285,8 @@ if esp.triggerName() == "ns" then [{
 		testns := testutil.TmpNamespace(t, c)
 
 		res := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "configmaps",
@@ -355,10 +334,8 @@ local trigger = esp.triggerData();
 
 		for i := range 3 {
 			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test" + strconv.Itoa(i),
-					Namespace: testns,
-				},
+				Name:      "test" + strconv.Itoa(i),
+				Namespace: testns,
 			}
 			require.NoError(t, c.Create(ctx, cm))
 		}
@@ -379,19 +356,15 @@ local trigger = esp.triggerData();
 
 		for i := range 500 {
 			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test" + strconv.Itoa(i),
-					Namespace: testns,
-				},
+				Name:      "test" + strconv.Itoa(i),
+				Namespace: testns,
 			}
 			require.NoError(t, c.Create(ctx, cm))
 		}
 
 		res := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "cms",
@@ -427,7 +400,7 @@ local cms = esp.context()["cms"];
 			var cms []string
 			require.NoError(t, json.Unmarshal([]byte(cm.Data["cms"]), &cms))
 			expected := make([]string, 0, 500)
-			for i := 0; i < 500; i++ {
+			for i := range 500 {
 				if i == 1 || i == 3 {
 					continue
 				}
@@ -494,19 +467,15 @@ local cms = esp.context()["cms"];
 
 		for i := range 3 {
 			cm := &networkingv1.NetworkPolicy{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test" + strconv.Itoa(i),
-					Namespace: testns,
-				},
+				Name:      "test" + strconv.Itoa(i),
+				Namespace: testns,
 			}
 			require.NoError(t, c.Create(ctx, cm))
 		}
 
 		res := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "netpols",
@@ -551,10 +520,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `[null, {apiVersion: "v1", kind: "ConfigMap", metadata: {name: "test"}} , null]`,
 			},
@@ -576,10 +543,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `glug`,
 			},
@@ -602,10 +567,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `glug`,
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{
@@ -622,10 +585,8 @@ local netpols = esp.context().netpols;
 		require.NoError(t, c.Create(ctx, mr))
 
 		cm := &corev1.ConfigMap{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trigger",
-				Namespace: testns,
-			},
+			Name:      "trigger",
+			Namespace: testns,
 		}
 		require.NoError(t, c.Create(ctx, cm))
 
@@ -651,10 +612,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{
 					{Name: "test"},
@@ -691,10 +650,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{
 					{Name: "test"},
@@ -731,10 +688,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `[]`,
 				ServiceAccountRef: corev1.LocalObjectReference{
@@ -770,10 +725,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `"glug"`,
 			},
@@ -796,10 +749,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{apiVersion: "v1", kind: "DoesNotExist"}`,
 			},
@@ -822,10 +773,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{
 					{
@@ -867,14 +816,10 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		cmToPatch := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "test",
+			Namespace:  testns,
 			Data: map[string]string{
 				"test": "test",
 			},
@@ -883,10 +828,8 @@ local netpols = esp.context().netpols;
 		require.NoError(t, c.Patch(ctx, cmToPatch, client.Apply, client.FieldOwner(origOwner)))
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{
 					apiVersion: "v1",
@@ -938,14 +881,10 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		cmToPatch := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "test",
+			Namespace:  testns,
 			Data: map[string]string{
 				"test": "test",
 			},
@@ -954,10 +893,8 @@ local netpols = esp.context().netpols;
 		require.NoError(t, c.Patch(ctx, cmToPatch, client.Apply, client.FieldOwner(origOwner)))
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{
 					apiVersion: "v1",
@@ -1019,14 +956,10 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		cmToPatch := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "test",
+			Namespace:  testns,
 			Data: map[string]string{
 				"test": "test",
 			},
@@ -1035,10 +968,8 @@ local netpols = esp.context().netpols;
 		require.NoError(t, c.Patch(ctx, cmToPatch, client.Apply, client.FieldOwner(origOwner)))
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{
 					apiVersion: "v1",
@@ -1090,14 +1021,10 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		cmToPatch := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "test",
+			Namespace:  testns,
 			Data: map[string]string{
 				"test": "test",
 			},
@@ -1106,10 +1033,8 @@ local netpols = esp.context().netpols;
 		require.NoError(t, c.Patch(ctx, cmToPatch, client.Apply, client.FieldOwner(origOwner)))
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{
 					apiVersion: "v1",
@@ -1171,10 +1096,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `[
 					{
@@ -1226,10 +1149,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{
 					apiVersion: "v1",
@@ -1277,10 +1198,8 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `{
 					apiVersion: "v1",
@@ -1338,23 +1257,17 @@ local netpols = esp.context().netpols;
 		testns := testutil.TmpNamespace(t, c)
 
 		cmToPatch := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
-			Data: map[string]string{},
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "test",
+			Namespace:  testns,
+			Data:       map[string]string{},
 		}
 		require.NoError(t, c.Create(ctx, cmToPatch))
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{
 					{
@@ -1457,19 +1370,15 @@ local netpols = esp.context().netpols;
 
 		for i := range 4 {
 			cm := &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
+				APIVersion: "v1",
+				Kind:       "ConfigMap",
+				Name:       "test" + strconv.Itoa(i),
+				Namespace:  testns,
+				Annotations: map[string]string{
+					"index": strconv.Itoa(i),
 				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test" + strconv.Itoa(i),
-					Namespace: testns,
-					Annotations: map[string]string{
-						"index": strconv.Itoa(i),
-					},
-					Labels: map[string]string{
-						"managed": "true",
-					},
+				Labels: map[string]string{
+					"managed": "true",
 				},
 				Data: map[string]string{
 					"test": "test",
@@ -1479,10 +1388,8 @@ local netpols = esp.context().netpols;
 		}
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "cms",
@@ -1546,10 +1453,8 @@ std.map(
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				ApplyOptions: espejotev1alpha1.ApplyOptions{
 					Force: true,
@@ -1584,10 +1489,8 @@ local esp = import 'espejote.libsonnet';
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{{
 					Name: "trigger",
@@ -1627,10 +1530,8 @@ if esp.triggerName() == 'trigger' then (
 		require.NoError(t, c.Create(ctx, mr))
 
 		triggerNetPol := &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "trigger",
-				Namespace: testns,
-			},
+			Name:      "trigger",
+			Namespace: testns,
 		}
 		require.NoError(t, c.Create(ctx, triggerNetPol))
 
@@ -1657,14 +1558,10 @@ if esp.triggerName() == 'trigger' then (
 		testns := testutil.TmpNamespace(t, c)
 
 		contextCM := &corev1.ConfigMap{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: "v1",
-				Kind:       "ConfigMap",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "context",
-				Namespace: testns,
-			},
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       "context",
+			Namespace:  testns,
 			Data: map[string]string{
 				"test": "test",
 			},
@@ -1672,10 +1569,8 @@ if esp.triggerName() == 'trigger' then (
 		require.NoError(t, c.Patch(ctx, contextCM, client.Apply, client.FieldOwner("test")))
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{{
 					Name: "trigger",
@@ -1727,8 +1622,8 @@ if esp.triggerName() == 'trigger' then {
 		}, 5*time.Second, 100*time.Millisecond)
 
 		require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(mr), mr))
-		mr.Spec.Triggers[0].WatchResource.StripManagedFields = ptr.To(false)
-		mr.Spec.Context[0].Resource.StripManagedFields = ptr.To(false)
+		mr.Spec.Triggers[0].WatchResource.StripManagedFields = new(false)
+		mr.Spec.Context[0].Resource.StripManagedFields = new(false)
 		require.NoError(t, c.Update(ctx, mr))
 
 		require.EventuallyWithT(t, func(t *assert.CollectT) {
@@ -1749,10 +1644,8 @@ if esp.triggerName() == 'trigger' then {
 
 		for i := range 100 {
 			cm := &corev1.ConfigMap{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test" + strconv.Itoa(i),
-					Namespace: testns,
-				},
+				Name:      "test" + strconv.Itoa(i),
+				Namespace: testns,
 			}
 			if i%2 == 0 {
 				cm.Labels = map[string]string{
@@ -1763,10 +1656,8 @@ if esp.triggerName() == 'trigger' then {
 		}
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Triggers: []espejotev1alpha1.ManagedResourceTrigger{{
 					Name: "matching-cms",
@@ -1807,7 +1698,7 @@ if esp.triggerName() == 'trigger' then {
 					// We still should cap it as there might be more than two reconciles because of cache wait or apply conflicts.
 					if metricHasLabelPair("namespace", testns)(m) && metricHasLabelPair("trigger", "matching-cms")(m) {
 						if m.GetCounter().GetValue() > 2 {
-							m.Counter.Value = ptr.To(float64(2))
+							m.Counter.Value = new(float64(2))
 						}
 						return true
 					}
@@ -1865,10 +1756,8 @@ espejote_cache_size_bytes{managedresource="test",name="matching-cms",namespace="
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Template: `
 local esp = import 'espejote.libsonnet';
@@ -1940,17 +1829,15 @@ local cm(name) = {
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test",
-				Namespace: testns,
-			},
+			Name:      "test",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "context",
 					Resource: espejotev1alpha1.ContextResource{
 						APIVersion: "v1",
 						Kind:       "ConfigMap",
-						Namespace:  ptr.To("zzz-test-blocking"),
+						Namespace:  new("zzz-test-blocking"),
 					},
 				}},
 				Template: `null`,
@@ -1987,17 +1874,15 @@ local cm(name) = {
 		testns := testutil.TmpNamespace(t, c)
 
 		mr := &espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-error",
-				Namespace: testns,
-			},
+			Name:      "test-error",
+			Namespace: testns,
 			Spec: espejotev1alpha1.ManagedResourceSpec{
 				Context: []espejotev1alpha1.ManagedResourceContext{{
 					Name: "context",
 					Resource: espejotev1alpha1.ContextResource{
 						APIVersion: "v1",
 						Kind:       "Secret",
-						Namespace:  ptr.To("zzz-test-forbidden"),
+						Namespace:  new("zzz-test-forbidden"),
 					},
 				}},
 				CacheSyncTimeout: metav1.Duration{Duration: time.Second},

--- a/controllers/metrics_test.go
+++ b/controllers/metrics_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,25 +18,19 @@ import (
 func Test_ManagedResourceStatusCollector(t *testing.T) {
 	c := buildFakeClient(t,
 		&espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "empty",
-				Namespace: "default",
-			},
+			Name:      "empty",
+			Namespace: "default",
 		},
 		&espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "ready",
-				Namespace: "default",
-			},
+			Name:      "ready",
+			Namespace: "default",
 			Status: espejotev1alpha1.ManagedResourceStatus{
 				Status: "Ready",
 			},
 		},
 		&espejotev1alpha1.ManagedResource{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "error",
-				Namespace: "default",
-			},
+			Name:      "error",
+			Namespace: "default",
 			Status: espejotev1alpha1.ManagedResourceStatus{
 				Status: "DependencyConfigurationError",
 			},

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/vshn/espejote
 
-go 1.26.5
+go 1.27.1
 
 require (
 	github.com/DmitriyVTitov/size v1.5.0

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	espejotev1alpha1 "github.com/vshn/espejote/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -50,20 +49,16 @@ func TmpNamespace(t *testing.T, c client.Client) string {
 	t.Helper()
 
 	ns := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "espejote-test-",
-			Annotations: map[string]string{
-				"test.espejote.vshn.net/name": t.Name(),
-			},
+		GenerateName: "espejote-test-",
+		Annotations: map[string]string{
+			"test.espejote.vshn.net/name": t.Name(),
 		},
 	}
 	require.NoError(t, c.Create(t.Context(), ns))
 
 	defaultSA := &corev1.ServiceAccount{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "default",
-			Namespace: ns.Name,
-		},
+		Name:      "default",
+		Namespace: ns.Name,
 	}
 	require.NoError(t, c.Create(t.Context(), defaultSA))
 


### PR DESCRIPTION
Removed `GOEXPERIMENT=jsonv2`, this is now stable. Ran `go fix` which removes the now no longer necessary `ptr.To`, `new()` takes an expression now, and fixes some inlining.

## Checklist

- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog
